### PR TITLE
feat(assert): dependence only trait, implementation, inheritance and attribut

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,10 @@ php bin/structura analyze
   - [toBeTraits()](#tobetraits)
 - 🔗 Dependencies
   - [dependsOnlyOn()](#dependsonlyon)
+  - [dependsOnlyOnAttribut](#dependsonlyonattribut)
+  - [dependsOnlyOnImplementation](#dependsonlyonimplementation)
+  - [dependsOnlyOnInheritance](#dependsonlyoninheritance)
+  - [dependsOnlyOnUseTrait](#dependsonlyonusetrait)
   - [toNotDependsOn()](#tonotdependson)
 - 🧲 Relation
   - [toExtend()](#toextend)
@@ -339,6 +343,8 @@ $this
 
 ### dependsOnlyOn()
 
+You can use [regexes](https://www.php.net/manual/en/reference.pcre.pattern.syntax.php) to select dependencies.
+
 ```php
 $this
   ->allClasses()
@@ -350,12 +356,65 @@ $this
   );
 ```
 
-You can use [regexes](https://www.php.net/manual/en/reference.pcre.pattern.syntax.php) to select
-dependencies
+### dependsOnlyOnAttribut()
 
-If you use the rule
-classes ([toExtend()](#toextend), [toImplement()](#toimplement), [toOnlyImplement()](#toonlyimplement), [toHaveAttribute()](#tohaveattribute), [toOnlyUseTrait()](#toonlyusetrait), [toUseTrait()](#tousetrait)),
-they are included by default in the permitted dependencies.
+If you use the rule classes [toHaveAttribute()](#tohaveattribute), they are included by default in the permitted dependencies.
+
+```php
+$this
+  ->allClasses()
+  ->should(fn(Expr $expr) => $expr
+    ->dependsOnlyOnAttribut(
+        names: [\Attribute::class, /* ... */],
+        patterns: ['Attributes\Custom.+', /* ... */],
+    )
+  );
+```
+
+### dependsOnlyOnImplementation()
+
+If you use the rule classes [toImplement()](#toimplement) and [toOnlyImplement()](#toonlyimplement) they are included by default in the permitted dependencies.
+
+```php
+$this
+  ->allClasses()
+  ->should(fn(Expr $expr) => $expr
+    ->dependsOnlyOnImplementation(
+        names: [\ArrayAccess::class, /* ... */],
+        patterns: ['Contracts\Dto.+', /* ... */],
+    )
+  );
+```
+
+### dependsOnlyOnInheritance()
+
+If you use the rule classes [toExtend()](#toextend) they are included by default in the permitted dependencies.
+
+```php
+$this
+  ->allClasses()
+  ->should(fn(Expr $expr) => $expr
+    ->dependsOnlyOnInheritance(
+        names: [Controller::class, /* ... */],
+        patterns: ['Controllers\Admin.+', /* ... */],
+    )
+  );
+```
+
+### dependsOnlyOnUseTrait()
+
+If you use the rule classes [toUseTrait()](#tousetrait) and [toOnlyUseTrait()](#toonlyusetrait) they are included by default in the permitted dependencies.
+
+```php
+$this
+  ->allClasses()
+  ->should(fn(Expr $expr) => $expr
+    ->dependsOnlyOnUseTrait(
+        names: [\HasFactor::class, /* ... */],
+        patterns: ['Concerns\Models.+', /* ... */],
+    )
+  );
+```
 
 ### toNotDependsOn()
 

--- a/src/Asserts/DependsOnlyOnAttribut.php
+++ b/src/Asserts/DependsOnlyOnAttribut.php
@@ -6,10 +6,11 @@ namespace StructuraPhp\Structura\Asserts;
 
 use StructuraPhp\Structura\Concerns\Arr;
 use StructuraPhp\Structura\Contracts\ExprInterface;
+use StructuraPhp\Structura\Enums\DependenciesType;
 use StructuraPhp\Structura\ValueObjects\ClassDescription;
 use StructuraPhp\Structura\ValueObjects\ViolationValueObject;
 
-final readonly class DependsOnlyOn implements ExprInterface
+final readonly class DependsOnlyOnAttribut implements ExprInterface
 {
     use Arr;
 
@@ -26,7 +27,7 @@ final readonly class DependsOnlyOn implements ExprInterface
     public function __toString(): string
     {
         return \sprintf(
-            'depends only on these namespaces <promote>%s</promote>',
+            'depends only on attribut <promote>%s</promote>',
             $this->implodeMore(array_merge($this->names, $this->patterns)),
         );
     }
@@ -35,10 +36,10 @@ final readonly class DependsOnlyOn implements ExprInterface
     {
         $dependencies = array_merge(
             $this->names,
-            $class->getDependenciesByPatterns($this->patterns),
+            $class->getDependenciesByPatterns($this->patterns, DependenciesType::Attributes),
         );
 
-        return array_diff($class->getDependencies(), array_unique($dependencies)) === [];
+        return array_diff($class->getAttributeNames(), array_unique($dependencies)) === [];
     }
 
     public function getViolation(ClassDescription $class): ViolationValueObject
@@ -46,14 +47,14 @@ final readonly class DependsOnlyOn implements ExprInterface
         $authorisedDependence = array_merge($this->names, $this->patterns);
         $dependencies = array_merge(
             $this->names,
-            $class->getDependenciesByPatterns($this->patterns),
+            $class->getDependenciesByPatterns($this->patterns, DependenciesType::Attributes),
         );
-        $violations = array_diff($class->getDependencies(), $dependencies);
+        $violations = array_diff($class->getAttributeNames(), $dependencies);
         sort($violations);
 
         return new ViolationValueObject(
             \sprintf(
-                'Resource <promote>%s</promote> must depends only on these namespaces %s but depends %s',
+                'Resource <promote>%s</promote> must use attributes on these namespaces %s but use attributes %s',
                 $class->isAnonymous()
                     ? 'Anonymous'
                     : $class->namespace,

--- a/src/Asserts/DependsOnlyOnImplementation.php
+++ b/src/Asserts/DependsOnlyOnImplementation.php
@@ -6,10 +6,11 @@ namespace StructuraPhp\Structura\Asserts;
 
 use StructuraPhp\Structura\Concerns\Arr;
 use StructuraPhp\Structura\Contracts\ExprInterface;
+use StructuraPhp\Structura\Enums\DependenciesType;
 use StructuraPhp\Structura\ValueObjects\ClassDescription;
 use StructuraPhp\Structura\ValueObjects\ViolationValueObject;
 
-final readonly class DependsOnlyOn implements ExprInterface
+final readonly class DependsOnlyOnImplementation implements ExprInterface
 {
     use Arr;
 
@@ -26,7 +27,7 @@ final readonly class DependsOnlyOn implements ExprInterface
     public function __toString(): string
     {
         return \sprintf(
-            'depends only on these namespaces <promote>%s</promote>',
+            'depends only on inheritance <promote>%s</promote>',
             $this->implodeMore(array_merge($this->names, $this->patterns)),
         );
     }
@@ -35,10 +36,10 @@ final readonly class DependsOnlyOn implements ExprInterface
     {
         $dependencies = array_merge(
             $this->names,
-            $class->getDependenciesByPatterns($this->patterns),
+            $class->getDependenciesByPatterns($this->patterns, DependenciesType::Interfaces),
         );
 
-        return array_diff($class->getDependencies(), array_unique($dependencies)) === [];
+        return array_diff($class->getInterfaceNames(), array_unique($dependencies)) === [];
     }
 
     public function getViolation(ClassDescription $class): ViolationValueObject
@@ -46,14 +47,14 @@ final readonly class DependsOnlyOn implements ExprInterface
         $authorisedDependence = array_merge($this->names, $this->patterns);
         $dependencies = array_merge(
             $this->names,
-            $class->getDependenciesByPatterns($this->patterns),
+            $class->getDependenciesByPatterns($this->patterns, DependenciesType::Interfaces),
         );
-        $violations = array_diff($class->getDependencies(), $dependencies);
+        $violations = array_diff($class->getInterfaceNames(), $dependencies);
         sort($violations);
 
         return new ViolationValueObject(
             \sprintf(
-                'Resource <promote>%s</promote> must depends only on these namespaces %s but depends %s',
+                'Resource <promote>%s</promote> must inherit on these namespaces %s but implement %s',
                 $class->isAnonymous()
                     ? 'Anonymous'
                     : $class->namespace,

--- a/src/Asserts/DependsOnlyOnInheritance.php
+++ b/src/Asserts/DependsOnlyOnInheritance.php
@@ -6,10 +6,11 @@ namespace StructuraPhp\Structura\Asserts;
 
 use StructuraPhp\Structura\Concerns\Arr;
 use StructuraPhp\Structura\Contracts\ExprInterface;
+use StructuraPhp\Structura\Enums\DependenciesType;
 use StructuraPhp\Structura\ValueObjects\ClassDescription;
 use StructuraPhp\Structura\ValueObjects\ViolationValueObject;
 
-final readonly class DependsOnlyOn implements ExprInterface
+final readonly class DependsOnlyOnInheritance implements ExprInterface
 {
     use Arr;
 
@@ -26,7 +27,7 @@ final readonly class DependsOnlyOn implements ExprInterface
     public function __toString(): string
     {
         return \sprintf(
-            'depends only on these namespaces <promote>%s</promote>',
+            'depends only on inheritance <promote>%s</promote>',
             $this->implodeMore(array_merge($this->names, $this->patterns)),
         );
     }
@@ -35,10 +36,10 @@ final readonly class DependsOnlyOn implements ExprInterface
     {
         $dependencies = array_merge(
             $this->names,
-            $class->getDependenciesByPatterns($this->patterns),
+            $class->getDependenciesByPatterns($this->patterns, DependenciesType::Extends),
         );
 
-        return array_diff($class->getDependencies(), array_unique($dependencies)) === [];
+        return array_diff($class->getExtendNames(), array_unique($dependencies)) === [];
     }
 
     public function getViolation(ClassDescription $class): ViolationValueObject
@@ -46,14 +47,14 @@ final readonly class DependsOnlyOn implements ExprInterface
         $authorisedDependence = array_merge($this->names, $this->patterns);
         $dependencies = array_merge(
             $this->names,
-            $class->getDependenciesByPatterns($this->patterns),
+            $class->getDependenciesByPatterns($this->patterns, DependenciesType::Extends),
         );
-        $violations = array_diff($class->getDependencies(), $dependencies);
+        $violations = array_diff($class->getExtendNames(), $dependencies);
         sort($violations);
 
         return new ViolationValueObject(
             \sprintf(
-                'Resource <promote>%s</promote> must depends only on these namespaces %s but depends %s',
+                'Resource <promote>%s</promote> must inherit on these namespaces %s but inherits %s',
                 $class->isAnonymous()
                     ? 'Anonymous'
                     : $class->namespace,

--- a/src/Asserts/DependsOnlyOnUseTrait.php
+++ b/src/Asserts/DependsOnlyOnUseTrait.php
@@ -6,10 +6,11 @@ namespace StructuraPhp\Structura\Asserts;
 
 use StructuraPhp\Structura\Concerns\Arr;
 use StructuraPhp\Structura\Contracts\ExprInterface;
+use StructuraPhp\Structura\Enums\DependenciesType;
 use StructuraPhp\Structura\ValueObjects\ClassDescription;
 use StructuraPhp\Structura\ValueObjects\ViolationValueObject;
 
-final readonly class DependsOnlyOn implements ExprInterface
+final readonly class DependsOnlyOnUseTrait implements ExprInterface
 {
     use Arr;
 
@@ -26,7 +27,7 @@ final readonly class DependsOnlyOn implements ExprInterface
     public function __toString(): string
     {
         return \sprintf(
-            'depends only on these namespaces <promote>%s</promote>',
+            'to use trait on these namespaces <promote>%s</promote>',
             $this->implodeMore(array_merge($this->names, $this->patterns)),
         );
     }
@@ -35,10 +36,10 @@ final readonly class DependsOnlyOn implements ExprInterface
     {
         $dependencies = array_merge(
             $this->names,
-            $class->getDependenciesByPatterns($this->patterns),
+            $class->getDependenciesByPatterns($this->patterns, DependenciesType::Traits),
         );
 
-        return array_diff($class->getDependencies(), array_unique($dependencies)) === [];
+        return array_diff($class->getTraitNames(), array_unique($dependencies)) === [];
     }
 
     public function getViolation(ClassDescription $class): ViolationValueObject
@@ -46,14 +47,14 @@ final readonly class DependsOnlyOn implements ExprInterface
         $authorisedDependence = array_merge($this->names, $this->patterns);
         $dependencies = array_merge(
             $this->names,
-            $class->getDependenciesByPatterns($this->patterns),
+            $class->getDependenciesByPatterns($this->patterns, DependenciesType::Traits),
         );
-        $violations = array_diff($class->getDependencies(), $dependencies);
+        $violations = array_diff($class->getTraitNames(), $dependencies);
         sort($violations);
 
         return new ViolationValueObject(
             \sprintf(
-                'Resource <promote>%s</promote> must depends only on these namespaces %s but depends %s',
+                'Resource <promote>%s</promote> must use traits on these namespaces %s but uses these traits %s',
                 $class->isAnonymous()
                     ? 'Anonymous'
                     : $class->namespace,

--- a/src/Enums/DependenciesType.php
+++ b/src/Enums/DependenciesType.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StructuraPhp\Structura\Enums;
+
+enum DependenciesType
+{
+    case All;
+    case Interfaces;
+    case Extends;
+    case Traits;
+    case Attributes;
+}

--- a/src/Services/ParseService.php
+++ b/src/Services/ParseService.php
@@ -14,7 +14,7 @@ use PhpParser\Parser;
 use PhpParser\ParserFactory;
 use StructuraPhp\Structura\ValueObjects\ClassDescription;
 use StructuraPhp\Structura\Visitors\ClassDescriptionVisitor;
-use StructuraPhp\Structura\Visitors\NamespaceVisitor;
+use StructuraPhp\Structura\Visitors\DependanciesVisitor;
 use Symfony\Component\Finder\Finder;
 
 final readonly class ParseService
@@ -25,14 +25,14 @@ final readonly class ParseService
 
     private ClassDescriptionVisitor $classDescriptionVisitor;
 
-    private NamespaceVisitor $namespaceVisitor;
+    private DependanciesVisitor $namespaceVisitor;
 
     public function __construct()
     {
         $this->parser = (new ParserFactory())->createForHostVersion();
 
         $this->classDescriptionVisitor = new ClassDescriptionVisitor();
-        $this->namespaceVisitor = new NamespaceVisitor();
+        $this->namespaceVisitor = new DependanciesVisitor();
 
         $this->nodeTraverser = new NodeTraverser(
             new NameResolver(),

--- a/tests/Helper/ArchitectureAsserts.php
+++ b/tests/Helper/ArchitectureAsserts.php
@@ -40,7 +40,7 @@ trait ArchitectureAsserts
 
         $violations = $assertBuilder->getViolations();
         foreach ($assertBuilder->getPass() as $key => $value) {
-            Assert::assertFalse((bool) $value);
+            Assert::assertFalse((bool) $value, $message);
             Assert::assertSame(implode(', ', $violations[$key] ?? []), $message);
         }
     }

--- a/tests/Unit/Asserts/DependsOnlyOnAttributTest.php
+++ b/tests/Unit/Asserts/DependsOnlyOnAttributTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StructuraPhp\Structura\Tests\Unit\Asserts;
+
+use Generator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use SensitiveParameter;
+use StructuraPhp\Structura\Asserts\DependsOnlyOnAttribut;
+use StructuraPhp\Structura\Expr;
+use StructuraPhp\Structura\Tests\Helper\ArchitectureAsserts;
+
+#[CoversClass(DependsOnlyOnAttribut::class)]
+#[CoversMethod(Expr::class, 'dependsOnlyOnAttribut')]
+final class DependsOnlyOnAttributTest extends TestCase
+{
+    use ArchitectureAsserts;
+
+    #[DataProvider('getClassLikeWithInheritance')]
+    public function testToExtend(string $raw): void
+    {
+        $rules = $this
+            ->allClasses()
+            ->fromRaw($raw)
+            ->should(
+                static fn (Expr $assert): Expr => $assert
+                    ->dependsOnlyOnAttribut(
+                        names: SensitiveParameter::class,
+                        patterns: 'Dependencies\Acme\.*',
+                    ),
+            );
+
+        self::assertRulesPass($rules);
+    }
+
+    #[DataProvider('getClassLikeWithoutInheritance')]
+    public function testShouldFailToExtendsWithInterface(string $raw): void
+    {
+        $rules = $this
+            ->allClasses()
+            ->fromRaw($raw)
+            ->should(
+                static fn (Expr $assert): Expr => $assert
+                    ->dependsOnlyOnAttribut(
+                        names: SensitiveParameter::class,
+                        patterns: 'Dependencies\Acme\.*',
+                    ),
+            );
+
+        self::assertRulesViolation(
+            $rules,
+            \sprintf(
+                'Resource <promote>Foo</promote> must use attributes on these namespaces %s, %s but use attributes %s',
+                SensitiveParameter::class,
+                'Dependencies\Acme\.*',
+                'BadAttribute',
+            ),
+        );
+    }
+
+    public static function getClassLikeWithInheritance(): Generator
+    {
+        yield 'without attributs' => ['<?php class Foo {}'];
+
+        yield 'without attributs and another dependency' => ['<?php use \ArrayAccess; class Foo {}'];
+
+        yield 'with name' => ['<?php #[\SensitiveParameter] class Foo {}'];
+
+        yield 'with pattern' => ['<?php #[\Dependencies\Acme\Foo] class Foo {}'];
+
+        yield 'with name and pattern' => [
+            '<?php #[\Dependencies\Acme\Foo] #[\SensitiveParameter] class Foo {}',
+        ];
+    }
+
+    public static function getClassLikeWithoutInheritance(): Generator
+    {
+        yield 'with bad attribut' => ['<?php #[\BadAttribute] class Foo {}'];
+
+        yield 'with bad attribut and good pattern' => ['<?php #[\BadAttribute] #[\Dependencies\Acme\Foo] class Foo {}'];
+
+        yield 'with bad name and good name' => [
+            '<?php #[\BadAttribute] #[\SensitiveParameter] class Foo {}',
+        ];
+    }
+}

--- a/tests/Unit/Asserts/DependsOnlyOnImplementationTest.php
+++ b/tests/Unit/Asserts/DependsOnlyOnImplementationTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StructuraPhp\Structura\Tests\Unit\Asserts;
+
+use ArrayAccess;
+use Generator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use StructuraPhp\Structura\Asserts\DependsOnlyOnImplementation;
+use StructuraPhp\Structura\Expr;
+use StructuraPhp\Structura\Tests\Helper\ArchitectureAsserts;
+
+#[CoversClass(DependsOnlyOnImplementation::class)]
+#[CoversMethod(Expr::class, 'dependsOnlyOnImplementation')]
+final class DependsOnlyOnImplementationTest extends TestCase
+{
+    use ArchitectureAsserts;
+
+    #[DataProvider('getClassLikeWithInheritance')]
+    public function testToExtend(string $raw): void
+    {
+        $rules = $this
+            ->allClasses()
+            ->fromRaw($raw)
+            ->should(
+                static fn (Expr $assert): Expr => $assert
+                    ->dependsOnlyOnImplementation(
+                        names: ArrayAccess::class,
+                        patterns: 'Dependencies\Acme\.*',
+                    ),
+            );
+
+        self::assertRulesPass($rules);
+    }
+
+    #[DataProvider('getClassLikeWithoutInheritance')]
+    public function testShouldFailToExtendsWithInterface(string $raw): void
+    {
+        $rules = $this
+            ->allClasses()
+            ->fromRaw($raw)
+            ->should(
+                static fn (Expr $assert): Expr => $assert
+                    ->dependsOnlyOnImplementation(
+                        names: ArrayAccess::class,
+                        patterns: 'Dependencies\Acme\.*',
+                    ),
+            );
+
+        self::assertRulesViolation(
+            $rules,
+            \sprintf(
+                'Resource <promote>Foo</promote> must inherit on these namespaces %s, %s but implement %s',
+                ArrayAccess::class,
+                'Dependencies\Acme\.*',
+                'BadImplements',
+            ),
+        );
+    }
+
+    public static function getClassLikeWithInheritance(): Generator
+    {
+        yield 'without implements' => ['<?php class Foo {}'];
+
+        yield 'without implements and another dependency' => ['<?php use \ArrayAccess; class Foo {}'];
+
+        yield 'with name' => ['<?php class Foo implements \ArrayAccess {}'];
+
+        yield 'with pattern' => ['<?php class Foo implements \Dependencies\Acme\Foo {}'];
+
+        yield 'with name and pattern' => [
+            '<?php class Foo implements \ArrayAccess, \Dependencies\Acme\Foo {}',
+        ];
+    }
+
+    public static function getClassLikeWithoutInheritance(): Generator
+    {
+        yield 'with bad implements' => ['<?php class Foo implements \BadImplements {}'];
+
+        yield 'with bad implements and good pattern' => ['<?php class Foo implements \BadImplements, \Dependencies\Acme\Foo {}'];
+
+        yield 'with bad name and good name' => [
+            '<?php class Foo implements \BadImplements, \ArrayAccess {}',
+        ];
+    }
+}

--- a/tests/Unit/Asserts/DependsOnlyOnInheritanceTest.php
+++ b/tests/Unit/Asserts/DependsOnlyOnInheritanceTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StructuraPhp\Structura\Tests\Unit\Asserts;
+
+use Generator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use StructuraPhp\Structura\Asserts\DependsOnlyOnInheritance;
+use StructuraPhp\Structura\Expr;
+use StructuraPhp\Structura\Tests\Fixture\Http\ControllerBase;
+use StructuraPhp\Structura\Tests\Helper\ArchitectureAsserts;
+
+#[CoversClass(DependsOnlyOnInheritance::class)]
+#[CoversMethod(Expr::class, 'dependsOnlyOnInheritance')]
+final class DependsOnlyOnInheritanceTest extends TestCase
+{
+    use ArchitectureAsserts;
+
+    #[DataProvider('getClassLikeWithInheritance')]
+    public function testToExtend(string $raw): void
+    {
+        $rules = $this
+            ->allClasses()
+            ->fromRaw($raw)
+            ->should(
+                static fn (Expr $assert): Expr => $assert
+                    ->dependsOnlyOnInheritance(
+                        names: ControllerBase::class,
+                        patterns: 'Dependencies\Acme\.*',
+                    ),
+            );
+
+        self::assertRulesPass($rules);
+    }
+
+    #[DataProvider('getClassLikeWithoutInheritance')]
+    public function testShouldFailToExtendsWithInterface(string $raw): void
+    {
+        $rules = $this
+            ->allClasses()
+            ->fromRaw($raw)
+            ->should(
+                static fn (Expr $assert): Expr => $assert
+                    ->dependsOnlyOnInheritance(
+                        names: ControllerBase::class,
+                        patterns: 'Dependencies\Acme\.*',
+                    ),
+            );
+
+        self::assertRulesViolation(
+            $rules,
+            \sprintf(
+                'Resource <promote>Foo</promote> must inherit on these namespaces %s, %s but inherits %s',
+                ControllerBase::class,
+                'Dependencies\Acme\.*',
+                'BadExtends',
+            ),
+        );
+    }
+
+    public static function getClassLikeWithInheritance(): Generator
+    {
+        yield 'without extends' => ['<?php class Foo {}'];
+
+        yield 'without extends and another dependency' => ['<?php use \ArrayAccess; class Foo {}'];
+
+        yield 'with name' => ['<?php class Foo extends \StructuraPhp\Structura\Tests\Fixture\Http\ControllerBase {}'];
+
+        yield 'with pattern' => ['<?php class Foo extends \Dependencies\Acme\Foo {}'];
+
+        yield 'with name and pattern' => [
+            '<?php interface Foo extends \Dependencies\Acme\Foo, \StructuraPhp\Structura\Tests\Fixture\Http\ControllerBase {}',
+        ];
+    }
+
+    public static function getClassLikeWithoutInheritance(): Generator
+    {
+        yield 'with bad extends' => ['<?php class Foo extends \BadExtends {}'];
+
+        yield 'with bad extends and good pattern' => ['<?php interface Foo extends \BadExtends, \Dependencies\Acme\Foo {}'];
+
+        yield 'with bad name and good name' => [
+            '<?php interface Foo extends \BadExtends, \StructuraPhp\Structura\Tests\Fixture\Http\ControllerBase {}',
+        ];
+    }
+}

--- a/tests/Unit/Asserts/DependsOnlyOnTest.php
+++ b/tests/Unit/Asserts/DependsOnlyOnTest.php
@@ -60,10 +60,12 @@ final class DependsOnlyOnTest extends TestCase
         self::assertRulesViolation(
             $rules,
             \sprintf(
-                'Resource <promote>Foo</promote> must depends only on these namespaces %s, %s, %s, [1+]',
+                'Resource <promote>Foo</promote> must depends only on these namespaces %s but depends %s, %s, %s, %s',
+                'Depend\Bap',
                 ArrayAccess::class,
                 'Depend\Bar',
                 Exception::class,
+                Stringable::class,
             ),
         );
     }
@@ -78,9 +80,9 @@ final class DependsOnlyOnTest extends TestCase
             use Depend\Bap;
             use Depend\Bar;
             
-            class Foo implements \Stringable {
+            class Foo {
                 public function __construct(ArrayAccess $arrayAccess) {
-                    
+                    \Stringable::class;
                 }
 
                 public function __toString(): string {

--- a/tests/Unit/Asserts/DependsOnlyOnUseTraitTest.php
+++ b/tests/Unit/Asserts/DependsOnlyOnUseTraitTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StructuraPhp\Structura\Tests\Unit\Asserts;
+
+use Generator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use StructuraPhp\Structura\Asserts\DependsOnlyOnUseTrait;
+use StructuraPhp\Structura\Expr;
+use StructuraPhp\Structura\Tests\Fixture\Concerns\HasFactory;
+use StructuraPhp\Structura\Tests\Helper\ArchitectureAsserts;
+
+#[CoversClass(DependsOnlyOnUseTrait::class)]
+#[CoversMethod(Expr::class, 'dependsOnlyOnUseTrait')]
+final class DependsOnlyOnUseTraitTest extends TestCase
+{
+    use ArchitectureAsserts;
+
+    #[DataProvider('getClassLikeWithTrait')]
+    public function testToExtend(string $raw): void
+    {
+        $rules = $this
+            ->allClasses()
+            ->fromRaw($raw)
+            ->should(
+                static fn (Expr $assert): Expr => $assert
+                    ->dependsOnlyOnUseTrait(
+                        names: HasFactory::class,
+                        patterns: 'Dependencies\Acme\.*',
+                    ),
+            );
+
+        self::assertRulesPass($rules);
+    }
+
+    #[DataProvider('getClassLikeWithoutTrait')]
+    public function testShouldFailToExtendsWithInterface(string $raw): void
+    {
+        $rules = $this
+            ->allClasses()
+            ->fromRaw($raw)
+            ->should(
+                static fn (Expr $assert): Expr => $assert
+                    ->dependsOnlyOnUseTrait(
+                        names: HasFactory::class,
+                        patterns: 'Dependencies\Acme\.*',
+                    ),
+            );
+
+        self::assertRulesViolation(
+            $rules,
+            \sprintf(
+                'Resource <promote>Foo</promote> must use traits on these namespaces %s, %s but uses these traits BadTrait',
+                HasFactory::class,
+                'Dependencies\Acme\.*',
+            ),
+        );
+    }
+
+    public static function getClassLikeWithTrait(): Generator
+    {
+        yield 'without trait' => ['<?php class Foo {}'];
+
+        yield 'without trait and another dependency' => ['<?php use \ArrayAccess; class Foo {}'];
+
+        yield 'with name' => ['<?php class Foo { use \StructuraPhp\Structura\Tests\Fixture\Concerns\HasFactory; }'];
+
+        yield 'with pattern' => ['<?php class Foo { use \Dependencies\Acme\Foo; }'];
+
+        yield 'with name and pattern' => ['<?php class Foo { use \StructuraPhp\Structura\Tests\Fixture\Concerns\HasFactory, \Dependencies\Acme\Foo; }'];
+    }
+
+    public static function getClassLikeWithoutTrait(): Generator
+    {
+        yield 'with bad trait' => ['<?php class Foo { use \BadTrait; }'];
+
+        yield 'with bad trait and good pattern' => ['<?php class Foo { use \BadTrait, \Dependencies\Acme\Foo; }'];
+
+        yield 'with bad name and good name' => ['<?php class Foo { use \BadTrait, \StructuraPhp\Structura\Tests\Fixture\Concerns\HasFactory; }'];
+    }
+}

--- a/tests/Unit/Asserts/ToNotDependsOnTest.php
+++ b/tests/Unit/Asserts/ToNotDependsOnTest.php
@@ -79,9 +79,9 @@ final class ToNotDependsOnTest extends TestCase
             use Depend\Bap;
             use Depend\Bar;
             
-            class Foo implements \Stringable {
+            class Foo {
                 public function __construct(ArrayAccess $arrayAccess) {
-                    
+                    \Stringable::class;
                 }
 
                 public function __toString(): string {

--- a/tests/Unit/Services/AnalyseServiceTest.php
+++ b/tests/Unit/Services/AnalyseServiceTest.php
@@ -24,24 +24,24 @@ final class AnalyseServiceTest extends TestCase
 
         $result = $service->analyse();
 
-        self::assertSame(4, $result->countViolation);
-        self::assertSame(11, $result->countPass);
+        self::assertSame(5, $result->countViolation);
+        self::assertSame(10, $result->countPass);
         self::assertSame(1, $result->countWarning);
 
         $expected = <<<'EOF'
         <violation> ERROR </violation> Asserts architecture rules in StructuraPhp\Structura\Tests\Feature\TestAssert
-        24 classes from
+        28 classes from
          - dirs
         That
          - to implement <promote>StructuraPhp\Structura\Contracts\ExprInterface</promote>
         Should
          <green>✔</green> to be classes
-         <fire>✘</fire> to not depends on these namespaces <promote>StructuraPhp\Structura\ValueObjects\ClassDescription</promote> <fire>23 error(s)</fire>
+         <fire>✘</fire> to not depends on these namespaces <promote>StructuraPhp\Structura\ValueObjects\ClassDescription</promote> <fire>27 error(s)</fire>
          <green>✔</green> to have method <promote>__toString</promote>
          <green>✔</green> to use declare <promote>strict_types=1</promote>
          <green>✔</green> to have prefix <promote>To</promote> <warning>1 warning(s)</warning>
          <green>✔</green> to extend nothing
-         <fire>✘</fire> to not use trait <fire>3 error(s)</fire>
+         <fire>✘</fire> to not use trait <fire>7 error(s)</fire>
          <green>✔</green> to have method <promote>__construct</promote>
 
         <violation> ERROR </violation> Controllers architecture rules in StructuraPhp\Structura\Tests\Feature\TestController
@@ -54,7 +54,7 @@ final class AnalyseServiceTest extends TestCase
          <green>✔</green> to have suffix <promote>Controller</promote>
          <green>✔</green> to extend <promote>StructuraPhp\Structura\Tests\Fixture\Http\ControllerBase</promote>
          <fire>✘</fire> to have method <promote>__construct</promote> <fire>2 error(s)</fire>
-         <green>✔</green> depends only on these namespaces <promote>StructuraPhp\Structura\Tests\Fixture\Concerns\HasFactory, StructuraPhp\Structura\Tests\Fixture\Http\Controller\RoleController, StructuraPhp\Structura\Tests\Fixture\Contract\ShouldQueueInterface, [2+]</promote>
+         <fire>✘</fire> depends only on these namespaces <promote>StructuraPhp\Structura\Tests\Fixture\Concerns\HasFactory, StructuraPhp\Structura\Tests\Fixture\Http\Controller\RoleController, StructuraPhp\Structura\Tests\Fixture\Contract\ShouldQueueInterface, [1+]</promote> <fire>2 error(s)</fire>
 
         <pass> PASS </pass> Exceptions architecture rules in StructuraPhp\Structura\Tests\Feature\TestException
         2 classes from
@@ -66,7 +66,7 @@ final class AnalyseServiceTest extends TestCase
              & to extend <promote>BadMethodCallException</promote>
 
         <pass> PASS </pass> Asserts architecture rules in StructuraPhp\Structura\Tests\Feature\TestVoid
-        65 classes from
+        70 classes from
          - dirs
         That
         Should

--- a/tests/Unit/Services/ParseServiceTest.php
+++ b/tests/Unit/Services/ParseServiceTest.php
@@ -32,22 +32,25 @@ final class ParseServiceTest extends TestCase
                 'Dependency\Dependency2',
                 'Dependency\Dependency3',
                 'Dependency4\Shadow2',
-                'Dependency5',
-                'Dependency6',
-                'Dependency7',
-                'Dependency8',
-                'Dependency9',
-                'Dependency10',
+                // 'Dependency5', => inheritance
+                // 'Dependency6', => interface
+                // 'Dependency7', => interface
+                // 'Dependency8', => trait
+                // 'Dependency9', => trait
+                // 'Dependency10', => trait
                 'Dependency11',
                 'Dependency12',
-                'Dependency13',
+                // 'Dependency13', => attribut
                 'Dependency14',
                 'Dependency15',
-                'Dependency16',
+                // 'Dependency16', => attribut
                 'Dependency17',
                 'Dependency18',
                 'Dependency19',
-                'Dependency20',
+                'Dependency20_0',
+                'Dependency20_1',
+                'Dependency20_2',
+                'Dependency20_3',
                 'Dependency21',
                 'Dependency22',
                 'Dependency23',
@@ -58,6 +61,40 @@ final class ParseServiceTest extends TestCase
             ],
             $classDescription->getDependencies(),
         );
+    }
+
+    public function testClassDependencies2(): void
+    {
+        $raw = $this->getUseDependanciesClass();
+
+        $generator = $this->parseService->parseRaw($raw);
+        $classDescription = iterator_to_array($generator)[0];
+
+        self::assertSame(
+            [],
+            $classDescription->getDependencies(),
+        );
+    }
+
+    public function getUseDependanciesClass(): string
+    {
+        return <<<'PHP'
+            <?php
+
+            namespace Acme;
+
+            use Dependency\Dependency1;
+            use Dependency\Dependency2;
+            use Dependency\Dependency3;
+            use Dependency\Dependency4;
+            use Dependency\Shadow1;
+
+            #[Dependency1]
+            class Foo extends Dependency2 implements Dependency3
+            {
+                use Dependency4, Shadow1\Dependency5; 
+            }
+            PHP;
     }
 
     private function getClassLikeProvider(): string
@@ -74,10 +111,10 @@ final class ParseServiceTest extends TestCase
 
             use const Dependency\Const1, Dependency\Const2;
             use const Dependency\{Const3, Const4};
-            
+
             use function Dependency\Func1, Dependency\Func2;
-            
-            class Foo extends \Dependency5 implements \Dependency6, \Dependency7
+
+            class Foo extends \Dependency5 implements \Dependency6, Shadow1\Dependency7
             {
                 use \Dependency8, \Dependency9;
                 use \Dependency10;
@@ -102,7 +139,12 @@ final class ParseServiceTest extends TestCase
 
                     $this->arrayAccess['foo'] instanceof \Dependency19;
 
-                    new class implements \Dependency20 {};
+                    new class extends \Dependency20_0 implements \Dependency20_1 {
+                        use \Dependency20_2;
+
+                        #[\Dependency20_3]
+                        private int $i;
+                    };
 
                     fn(\Dependency22 $foo): \Dependency21 => $foo;
 
@@ -113,9 +155,9 @@ final class ParseServiceTest extends TestCase
                     } catch (\Dependency25 $e) {
 
                     }
-                    
+
                     Shadow1\Dependency26::class;
-                    
+
                     Shadow2\Dependency27::class;
                     Shadow2::class;
                 }


### PR DESCRIPTION
### Description

Separates the test from interface, inheritance, trait and attribute dependencies.
The aim is to avoid hijacking dependencies.
For example, if you authorize attributes, it's not an authorization elsewhere:

```php
<?php

namespace Acme;

use Dependency\Dependency1;
use Dependency\Dependency2;
use Dependency\Dependency3;
use Dependency\Dependency4;
use Dependency\Shadow1;

#[Dependency1] // OK
class Foo extends Dependency2 implements Dependency3 // OK
{
    use Dependency4, Shadow1\Dependency5; // OK
    
    public function error()
    {
        // KO 
        Dependency1::class;
        Dependency2::class;
        Dependency3::class;
        Dependency4::class;
        Shadow1\Dependency5::class;
    }
}
```