### PR TITLE
feat(assert): add to have no attribute and to have only attribute (#16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ php bin/structura analyze
   - [toBeInvokable()](#tobeinvokable)
   - [toBeReadonly()](#tobereadonly)
   - [toBeTraits()](#tobetraits)
-  - [toBeAttribute()](#tobetraits)
+  - [toBeAttribute()](#tobeattribute)
 - 🔗 Dependencies
   - [dependsOnlyOn()](#dependsonlyon)
   - [dependsOnlyOnAttribut](#dependsonlyonattribut)
@@ -346,6 +346,10 @@ $this
 
 ### toBeAttribute()
 
+- Must be a [syntax-compliant attribute](https://www.php.net/manual/en/language.attributes.classes.php), 
+- Must be instantiable by a [class reflection](https://www.php.net/manual/fr/language.attributes.reflection.php),
+- And uses [valid flags](https://www.php.net/manual/en/class.attribute.php#attribute.constants.target-class).
+
 ```php
 $this
   ->allClasses()
@@ -355,10 +359,10 @@ $this
   );
 ```
 
-Un attribut valide est une classe qui utilise \Attribut avec un flag valide et qui est instanciable
-
 ```php
-#[\Attribute()] // OK
+<?php
+
+[\Attribute(\Attribute::TARGET_CLASS_CONSTANT)] // OK
 class Foo {
 
 }
@@ -368,9 +372,8 @@ class Bar {
 
 }
 
-$class = new ReflectionClass(ValidAttr::class);
-$attributes = $class->getAttributes();
-array_map(fn($attribute) => $attribute->newInstance(), $attributes);
+(new ReflectionClass(Bar::class))->getAttributes()[0]->newInstance();
+// Fatal error: Uncaught Error: Attribute class "Custom" not found
 ```
 
 ### dependsOnlyOn()

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ php bin/structura analyze
   - [toBeInvokable()](#tobeinvokable)
   - [toBeReadonly()](#tobereadonly)
   - [toBeTraits()](#tobetraits)
+  - [toBeAttribute()](#tobetraits)
 - 🔗 Dependencies
   - [dependsOnlyOn()](#dependsonlyon)
   - [dependsOnlyOnAttribut](#dependsonlyonattribut)
@@ -341,6 +342,35 @@ $this
   ->should(
     static fn (Expr $assert): Expr => $assert->toBeTraits(),
   );
+```
+
+### toBeAttribute()
+
+```php
+$this
+  ->allClasses()
+  ->fromRaw('<?php #[\Attribute(\Attribute::TARGET_CLASS_CONSTANT)] class Foo {}')
+  ->should(
+    static fn (Expr $assert): Expr => $assert->toBeAttribute(\Attribute::TARGET_CLASS_CONSTANT),
+  );
+```
+
+Un attribut valide est une classe qui utilise \Attribut avec un flag valide et qui est instanciable
+
+```php
+#[\Attribute()] // OK
+class Foo {
+
+}
+
+#[Custom] // KO
+class Bar {
+
+}
+
+$class = new ReflectionClass(ValidAttr::class);
+$attributes = $class->getAttributes();
+array_map(fn($attribute) => $attribute->newInstance(), $attributes);
 ```
 
 ### dependsOnlyOn()

--- a/src/Asserts/ToBeAttribute.php
+++ b/src/Asserts/ToBeAttribute.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StructuraPhp\Structura\Asserts;
+
+use Attribute;
+use InvalidArgumentException;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\BinaryOp\BitwiseOr;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Identifier;
+use StructuraPhp\Structura\Contracts\ExprInterface;
+use StructuraPhp\Structura\Enums\ClassType;
+use StructuraPhp\Structura\ValueObjects\ClassDescription;
+use StructuraPhp\Structura\ValueObjects\ViolationValueObject;
+
+final readonly class ToBeAttribute implements ExprInterface
+{
+    public function __construct(
+        private int $flag,
+        private string $message = '',
+    ) {}
+
+    public function __toString(): string
+    {
+        return 'to be anonymous classes';
+    }
+
+    public function assert(ClassDescription $class): bool
+    {
+        if ($class->classType !== ClassType::Class_ && $class->attrGroups === []) {
+            return false;
+        }
+
+        foreach ($class->attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                if ($attr->name->toString() !== Attribute::class) {
+                    continue;
+                }
+
+                try {
+                    return $this->checkFlag($attr->args);
+                } catch (InvalidArgumentException $e) {
+                    return false;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public function getViolation(ClassDescription $class): ViolationValueObject
+    {
+        return new ViolationValueObject(
+            \sprintf(
+                'Resource <promote>%s</promote> must be an anonymous class',
+                $class->namespace,
+            ),
+            $this::class,
+            $class->lines,
+            $class->getFileBasename(),
+            $this->message,
+        );
+    }
+
+    /**
+     * @param array<int, Arg> $args
+     */
+    private function checkFlag(array $args): bool
+    {
+        if ($args === []) {
+            return Attribute::TARGET_ALL === $this->flag;
+        }
+
+        $flagsToCheck = 0;
+        foreach ($args as $arg) {
+            $targets = $this->extractTargetValues($arg->value);
+
+            foreach ($targets as $target) {
+                $flagsToCheck |= $this->getTargetValue($target);
+            }
+        }
+
+        return $flagsToCheck === $this->flag;
+    }
+
+    /**
+     * @param array<int,Expr>|Expr $node
+     *
+     * @return array<int,string>
+     */
+    private function extractTargetValues(array|Expr $node): array
+    {
+        $targets = [];
+
+        if ($node instanceof ClassConstFetch) {
+            $name = $node->name;
+            if (!$name instanceof Identifier) {
+                throw new InvalidArgumentException();
+            }
+
+            $targets[] = $name->name;
+        } elseif ($node instanceof BitwiseOr) {
+            $targets = array_merge($targets, $this->extractTargetValues($node->left));
+            $targets = array_merge($targets, $this->extractTargetValues($node->right));
+        } elseif (is_array($node)) {
+            foreach ($node as $child) {
+                $targets = array_merge($targets, $this->extractTargetValues($child));
+            }
+        } else {
+            throw new InvalidArgumentException();
+        }
+
+        return $targets;
+    }
+
+    private function getTargetValue(string $class): int
+    {
+        return match ($class) {
+            'TARGET_CLASS' => Attribute::TARGET_CLASS,
+            'TARGET_FUNCTION' => Attribute::TARGET_FUNCTION,
+            'TARGET_METHOD' => Attribute::TARGET_METHOD,
+            'TARGET_PROPERTY' => Attribute::TARGET_PROPERTY,
+            'TARGET_CLASS_CONSTANT' => Attribute::TARGET_CLASS_CONSTANT,
+            'TARGET_PARAMETER' => Attribute::TARGET_PARAMETER,
+            'TARGET_ALL' => Attribute::TARGET_ALL,
+            'IS_REPEATABLE' => Attribute::IS_REPEATABLE,
+            default => 0,
+        };
+    }
+}

--- a/src/Expr.php
+++ b/src/Expr.php
@@ -158,6 +158,9 @@ class Expr implements IteratorAggregate
         return $this->addExpr(new ToBeReadonly($message));
     }
 
+    /**
+     * @param int-mask-of<Attribute::IS_REPEATABLE|Attribute::TARGET_*> $flag
+     */
     public function toBeAttribute(int $flag = Attribute::TARGET_ALL, string $message = ''): self
     {
         return $this->addExpr(new ToBeAttribute($flag, $message));

--- a/src/Expr.php
+++ b/src/Expr.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace StructuraPhp\Structura;
 
+use Attribute;
 use Closure;
 use Generator;
 use IteratorAggregate;
@@ -14,6 +15,7 @@ use StructuraPhp\Structura\Asserts\DependsOnlyOnInheritance;
 use StructuraPhp\Structura\Asserts\DependsOnlyOnUseTrait;
 use StructuraPhp\Structura\Asserts\ToBeAbstract;
 use StructuraPhp\Structura\Asserts\ToBeAnonymousClasses;
+use StructuraPhp\Structura\Asserts\ToBeAttribute;
 use StructuraPhp\Structura\Asserts\ToBeClasses;
 use StructuraPhp\Structura\Asserts\ToBeEnums;
 use StructuraPhp\Structura\Asserts\ToBeFinal;
@@ -154,6 +156,11 @@ class Expr implements IteratorAggregate
     public function toBeReadonly(string $message = ''): self
     {
         return $this->addExpr(new ToBeReadonly($message));
+    }
+
+    public function toBeAttribute(int $flag = Attribute::TARGET_ALL, string $message = ''): self
+    {
+        return $this->addExpr(new ToBeAttribute($flag, $message));
     }
 
     /**

--- a/tests/Unit/Asserts/ToBeAttributeTest.php
+++ b/tests/Unit/Asserts/ToBeAttributeTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StructuraPhp\Structura\Tests\Unit\Asserts;
+
+use Attribute;
+use Generator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use StructuraPhp\Structura\Asserts\ToBeAttribute;
+use StructuraPhp\Structura\Expr;
+use StructuraPhp\Structura\Tests\Helper\ArchitectureAsserts;
+
+#[CoversClass(ToBeAttribute::class)]
+#[CoversMethod(Expr::class, 'toBeAttribute')]
+class ToBeAttributeTest extends TestCase
+{
+    use ArchitectureAsserts;
+
+    #[DataProvider('getClassLikeNonClasses')]
+    public function testToBeClasses(string $raw, int $flag): void
+    {
+        $rules = $this
+            ->allClasses()
+            ->fromRaw($raw)
+            ->should(
+                static fn (Expr $assert): Expr => $assert->toBeAttribute($flag),
+            );
+
+        self::assertRulesPass($rules);
+    }
+
+    public static function getClassLikeNonClasses(): Generator
+    {
+        yield 'class' => [
+            '<?php #[Attribute()] class Foo {};',
+            Attribute::TARGET_ALL,
+        ];
+
+        yield 'class 2' => [
+            '<?php #[Attribute(Attribute::TARGET_ALL)] class Foo {};',
+            Attribute::TARGET_ALL,
+        ];
+
+        yield 'class 3' => [
+            '<?php #[Attribute(Attribute::TARGET_CLASS_CONSTANT | Attribute::TARGET_PARAMETER)] class Foo {};',
+            Attribute::TARGET_PARAMETER | Attribute::TARGET_CLASS_CONSTANT,
+        ];
+    }
+}

--- a/tests/Unit/Asserts/ToBeAttributeTest.php
+++ b/tests/Unit/Asserts/ToBeAttributeTest.php
@@ -20,8 +20,11 @@ class ToBeAttributeTest extends TestCase
 {
     use ArchitectureAsserts;
 
-    #[DataProvider('getClassLikeNonClasses')]
-    public function testToBeClasses(string $raw, int $flag): void
+    /**
+     * @param int-mask-of<Attribute::IS_REPEATABLE|Attribute::TARGET_*> $flag
+     */
+    #[DataProvider('getClassLikeForPass')]
+    public function testToBeAttribute(string $raw, int $flag): void
     {
         $rules = $this
             ->allClasses()
@@ -33,21 +36,82 @@ class ToBeAttributeTest extends TestCase
         self::assertRulesPass($rules);
     }
 
-    public static function getClassLikeNonClasses(): Generator
+    #[DataProvider('getClasseLikeForFail')]
+    public function testShouldFailToBeAttribute(string $raw, string $exceptName = 'Foo'): void
     {
-        yield 'class' => [
+        $rules = $this
+            ->allClasses()
+            ->fromRaw($raw)
+            ->should(
+                static fn (Expr $assert): Expr => $assert->toBeAttribute(),
+            );
+
+        self::assertRulesViolation(
+            $rules,
+            \sprintf('Resource <promote>%s</promote> must be attributable', $exceptName),
+        );
+    }
+
+    public static function getClassLikeForPass(): Generator
+    {
+        yield 'default parameter' => [
             '<?php #[Attribute()] class Foo {};',
             Attribute::TARGET_ALL,
         ];
 
-        yield 'class 2' => [
+        yield 'target all' => [
             '<?php #[Attribute(Attribute::TARGET_ALL)] class Foo {};',
             Attribute::TARGET_ALL,
         ];
 
-        yield 'class 3' => [
+        yield 'with a multiple mask' => [
             '<?php #[Attribute(Attribute::TARGET_CLASS_CONSTANT | Attribute::TARGET_PARAMETER)] class Foo {};',
             Attribute::TARGET_PARAMETER | Attribute::TARGET_CLASS_CONSTANT,
+        ];
+    }
+
+    public static function getClasseLikeForFail(): Generator
+    {
+        yield 'anonymous class' => ['<?php new class {};', 'Anonymous'];
+
+        yield 'class' => [
+            '<?php class Foo {}',
+        ];
+
+        yield 'class with a bad parameter' => [
+            '<?php #[Attribute(1)] class Foo {};',
+        ];
+
+        yield 'abstract class' => [
+            '<?php abstract class Foo {}',
+        ];
+
+        yield 'abstract class with attributs' => [
+            '<?php #[Attribute()] abstract class Foo {}',
+        ];
+
+        yield 'enum' => [
+            '<?php enum Foo {}',
+        ];
+
+        yield 'enum with attributs' => [
+            '<?php #[Attribute()] enum Foo {}',
+        ];
+
+        yield 'trait' => [
+            '<?php trait Foo {}',
+        ];
+
+        yield 'trait with attributs' => [
+            '<?php #[Attribute()] trait Foo {}',
+        ];
+
+        yield 'interface' => [
+            '<?php interface Foo {}',
+        ];
+
+        yield 'interface with attributs' => [
+            '<?php #[Attribute()] interface Foo {}',
         ];
     }
 }

--- a/tests/Unit/Services/AnalyseServiceTest.php
+++ b/tests/Unit/Services/AnalyseServiceTest.php
@@ -30,13 +30,13 @@ final class AnalyseServiceTest extends TestCase
 
         $expected = <<<'EOF'
         <violation> ERROR </violation> Asserts architecture rules in StructuraPhp\Structura\Tests\Feature\TestAssert
-        30 classes from
+        31 classes from
          - dirs
         That
          - to implement <promote>StructuraPhp\Structura\Contracts\ExprInterface</promote>
         Should
          <green>✔</green> to be classes
-         <fire>✘</fire> to not depends on these namespaces <promote>StructuraPhp\Structura\ValueObjects\ClassDescription</promote> <fire>29 error(s)</fire>
+         <fire>✘</fire> to not depends on these namespaces <promote>StructuraPhp\Structura\ValueObjects\ClassDescription</promote> <fire>30 error(s)</fire>
          <green>✔</green> to have method <promote>__toString</promote>
          <green>✔</green> to use declare <promote>strict_types=1</promote>
          <green>✔</green> to have prefix <promote>To</promote> <warning>1 warning(s)</warning>
@@ -66,7 +66,7 @@ final class AnalyseServiceTest extends TestCase
              & to extend <promote>BadMethodCallException</promote>
 
         <pass> PASS </pass> Asserts architecture rules in StructuraPhp\Structura\Tests\Feature\TestVoid
-        72 classes from
+        73 classes from
          - dirs
         That
         Should


### PR DESCRIPTION

- Must be a [syntax-compliant attribute](https://www.php.net/manual/en/language.attributes.classes.php), 
- Must be instantiable by a [class reflection](https://www.php.net/manual/fr/language.attributes.reflection.php),
- And uses [valid flags](https://www.php.net/manual/en/class.attribute.php#attribute.constants.target-class).

```php
$this
  ->allClasses()
  ->fromRaw('<?php #[\Attribute(\Attribute::TARGET_CLASS_CONSTANT)] class Foo {}')
  ->should(
    static fn (Expr $assert): Expr => $assert->toBeAttribute(\Attribute::TARGET_CLASS_CONSTANT),
  );
```

```php
<?php

[\Attribute(\Attribute::TARGET_CLASS_CONSTANT)] // OK
class Foo {

}

#[Custom] // KO
class Bar {

}

(new ReflectionClass(Bar::class))->getAttributes()[0]->newInstance();
// Fatal error: Uncaught Error: Attribute class "Custom" not found
```