### PR TITLE
feat(assert): add have corresponding class

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ php bin/structura analyze
   - [toHavePrefix()](#tohaveprefix)
   - [toHaveSuffix()](#tohavesuffix)
 - 🕹️ Other
+  - [toHaveCorrespondingClass()](#tohavecorrespondingclass)
   - [toUseStrictTypes()](#tousestricttypes)
   - [toUseDeclare()](#tousedeclare)
   - [toBeInOneOfTheNamespaces()](#tobeinoneofthenamespaces)
@@ -662,6 +663,29 @@ $this
   ->allClasses()
   ->fromRaw('<?php class FooExemple {}')
   ->should(fn(Expr $expr) => $expr->toHaveSuffix('Exemple'));
+```
+
+### toHaveCorrespondingClass()
+
+Check the correspondence between a class and a mask.
+To build the mask, you have access to the description of the current class.
+
+For example, you can check whether each unit test class has a corresponding class in your project :
+
+```php
+$this
+    ->allClasses()
+    ->fromDir('tests/Unit')
+    ->should(
+        static fn(Expr $assert): Expr => $assert
+            ->toHaveCorrespondingClass(
+                static fn (ClassDescription $classDescription): string => preg_replace(
+                    '/^(.+?)\\\Tests\\\Unit\\\(.+?)(Test)$/',
+                    '$1\\\$2',
+                    $classDescription->namespace,
+                )
+            ),
+    );
 ```
 
 ### toUseStrictTypes()

--- a/src/Asserts/ToHaveCorrespondingClass.php
+++ b/src/Asserts/ToHaveCorrespondingClass.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StructuraPhp\Structura\Asserts;
+
+use Closure;
+use StructuraPhp\Structura\Contracts\ExprInterface;
+use StructuraPhp\Structura\ValueObjects\ClassDescription;
+use StructuraPhp\Structura\ValueObjects\ViolationValueObject;
+
+final readonly class ToHaveCorrespondingClass implements ExprInterface
+{
+    /**
+     * @param Closure(ClassDescription): string $callback
+     */
+    public function __construct(
+        private Closure $callback,
+        private string $message = '',
+    ) {}
+
+    public function __toString(): string
+    {
+        return 'to have corresponding class';
+    }
+
+    public function assert(ClassDescription $class): bool
+    {
+        $callback = $this->callback;
+        $className = $callback($class);
+
+        return class_exists($className);
+    }
+
+    public function getViolation(ClassDescription $class): ViolationValueObject
+    {
+        $callback = $this->callback;
+        $className = $callback($class);
+
+        return new ViolationValueObject(
+            \sprintf(
+                'Resource name <promote>%s</promote> must have corresponding class <promote>%s</promote>',
+                $class->isAnonymous()
+                    ? 'Anonymous'
+                    : $class->namespace,
+                $className,
+            ),
+            $this::class,
+            $class->lines,
+            $class->getFileBasename(),
+            $this->message,
+        );
+    }
+}

--- a/src/Concerns/Expr/OtherAssert.php
+++ b/src/Concerns/Expr/OtherAssert.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace StructuraPhp\Structura\Concerns\Expr;
 
+use Closure;
 use StructuraPhp\Structura\Asserts\NotToBeInOneOfTheNamespaces;
 use StructuraPhp\Structura\Asserts\ToBeInOneOfTheNamespaces;
+use StructuraPhp\Structura\Asserts\ToHaveCorrespondingClass;
 use StructuraPhp\Structura\Asserts\ToUseDeclare;
 use StructuraPhp\Structura\Expr;
 
@@ -14,6 +16,11 @@ use StructuraPhp\Structura\Expr;
  */
 trait OtherAssert
 {
+    public function toHaveCorrespondingClass(Closure $closure, string $message = ''): self
+    {
+        return $this->addExpr(new ToHaveCorrespondingClass($closure, $message));
+    }
+
     public function toUseStrictTypes(string $message = ''): self
     {
         return $this->toUseDeclare('strict_types', '1', $message);

--- a/tests/Unit/Asserts/ToHaveCorrespondingClassTest.php
+++ b/tests/Unit/Asserts/ToHaveCorrespondingClassTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StructuraPhp\Structura\Tests\Unit\Asserts;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\TestCase;
+use StructuraPhp\Structura\Asserts\ToHaveMethod;
+use StructuraPhp\Structura\Expr;
+use StructuraPhp\Structura\Tests\Helper\ArchitectureAsserts;
+use StructuraPhp\Structura\ValueObjects\ClassDescription;
+
+#[CoversClass(ToHaveMethod::class)]
+#[CoversMethod(Expr::class, 'toHaveCorrespondingClass')]
+class ToHaveCorrespondingClassTest extends TestCase
+{
+    use ArchitectureAsserts;
+
+    private const CORRESPONDENCE_ERROR = [
+        AndTest::class => 'StructuraPhp\Structura\Asserts\And',
+        NotDependsOnFunctionTest::class => 'StructuraPhp\Structura\Asserts\NotDependsOnFunction',
+        OrTest::class => 'StructuraPhp\Structura\Asserts\Or',
+        ToBeInterfaceTest::class => 'StructuraPhp\Structura\Asserts\ToBeInterface',
+        ToBeInvokableTest::class => 'StructuraPhp\Structura\Asserts\ToBeInvokable',
+        ToUseStrictTypesTest::class => 'StructuraPhp\Structura\Asserts\ToUseStrictTypes',
+    ];
+
+    public function testToHaveCorrespondingClass(): void
+    {
+        $rules = $this
+            ->allClasses()
+            ->fromDir(dirname(__DIR__) . '/Visitors')
+            ->should(
+                static fn (Expr $assert): Expr => $assert
+                    ->toHaveCorrespondingClass(
+                        static function (ClassDescription $classDescription): string {
+                            $classname = preg_replace(
+                                '/^(.+?)\\\Tests\\\Unit\\\(.+?)(Test)$/',
+                                '$1\\\$2',
+                                $classDescription->namespace ?? '',
+                            );
+
+                            return is_string($classname)
+                                ? $classname
+                                : throw new InvalidArgumentException('Classename must be a string');
+                        },
+                    ),
+            );
+
+        self::assertRulesPass(
+            $rules,
+            'to have corresponding class',
+        );
+    }
+
+    public function testShouldFailToHaveCorrespondingClass(): void
+    {
+        $rules = $this
+            ->allClasses()
+            ->fromDir(__DIR__)
+            ->should(
+                static fn (Expr $assert): Expr => $assert
+                    ->toHaveCorrespondingClass(
+                        static function (ClassDescription $classDescription): string {
+                            $classname = preg_replace(
+                                '/^(.+?)\\\Tests\\\Unit\\\(.+?)(Test)$/',
+                                '$1\\\$2',
+                                $classDescription->namespace ?? '',
+                            );
+
+                            return is_string($classname)
+                                ? $classname
+                                : throw new InvalidArgumentException('Classname not found');
+                        },
+                    ),
+            );
+
+        $output = [];
+        foreach (self::CORRESPONDENCE_ERROR as $class => $except) {
+            $output[] = sprintf(
+                'Resource name <promote>%s</promote> must have corresponding class <promote>%s</promote>',
+                $class,
+                $except,
+            );
+        }
+
+        self::assertRulesViolation(
+            $rules,
+            implode(', ', $output),
+        );
+    }
+}

--- a/tests/Unit/Services/AnalyseServiceTest.php
+++ b/tests/Unit/Services/AnalyseServiceTest.php
@@ -30,13 +30,13 @@ final class AnalyseServiceTest extends TestCase
 
         $expected = <<<'EOF'
         <violation> ERROR </violation> Asserts architecture rules in StructuraPhp\Structura\Tests\Feature\TestAssert
-        35 classes from
+        36 classes from
          - dirs
         That
          - to implement <promote>StructuraPhp\Structura\Contracts\ExprInterface</promote>
         Should
          <green>✔</green> to be classes
-         <fire>✘</fire> to not depends on these namespaces <promote>StructuraPhp\Structura\ValueObjects\ClassDescription</promote> <fire>34 error(s)</fire>
+         <fire>✘</fire> to not depends on these namespaces <promote>StructuraPhp\Structura\ValueObjects\ClassDescription</promote> <fire>35 error(s)</fire>
          <green>✔</green> to have method <promote>__toString</promote>
          <green>✔</green> to use declare <promote>strict_types=1</promote>
          <green>✔</green> to have prefix <promote>To</promote> <warning>1 warning(s)</warning>
@@ -66,7 +66,7 @@ final class AnalyseServiceTest extends TestCase
              & to extend <promote>BadMethodCallException</promote>
 
         <pass> PASS </pass> Asserts architecture rules in StructuraPhp\Structura\Tests\Feature\TestVoid
-        90 classes from
+        91 classes from
          - dirs
         That
         Should


### PR DESCRIPTION
### Description

Check the correspondence between a class and a mask.
To build the mask, you have access to the description of the current class.

For example, you can check whether each unit test class has a corresponding class in your project :

```php
$this
    ->allClasses()
    ->fromDir('tests/Unit')
    ->should(
        static fn(Expr $assert): Expr => $assert
            ->toHaveCorrespondingClass(
                static fn (ClassDescription $classDescription): string => preg_replace(
                    '/^(.+?)\\\Tests\\\Unit\\\(.+?)(Test)$/',
                    '$1\\\$2',
                    $classDescription->namespace,
                )
            ),
    );
```