### PR TITLE
feat(builder): add from raw multiple

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ $this->allScripts()
 
 If you choose script analysis, all PHP code can be analysed, but only rules can be used.
 
-### fromDir() and fromRaw()
+### fromDir(), fromRaw() and fromRawMultiple()
 
 Start with the `fromDir()` method, which takes the path of the files to be analysed.
 It can take a second closure parameter
@@ -148,10 +148,12 @@ to [customise the finder](https://symfony.com/doc/current/components/finder.html
 )
 ```
 
-`fromRaw()` method can be used to test PHP code in the form of a string:
+`fromRaw()` method can be used to test PHP code in the form of a string.
+You can provide a file name as the second parameter. If it is null, it will be set by default with the following pattern : `tmp\run_<count>.php`
 
 ```php
-->fromRaw('<?php
+->fromRaw(
+    raw: '<?php
             
     use ArrayAccess;
     use Depend\Bap;
@@ -159,11 +161,23 @@ to [customise the finder](https://symfony.com/doc/current/components/finder.html
             
     class Foo implements \Stringable {
         public function __construct(ArrayAccess $arrayAccess) {}
+    
+        public function __toString(): string {
+            return $this->arrayAccess[\'foo\'] ?? throw new \Exception();
+        }
+    }',
+    pathname: 'path/example_1.php'
+)
+```
 
-    public function __toString(): string {
-        return $this->arrayAccess['foo'] ?? throw new \Exception();
-    }
-}')
+`fromRawMultiple()` method can be used to test PHP code in the form of a string.
+You can provide a file name as an array key. If it is numeric, it will be set by default with the following pattern: `tmp\run_<count>.php`
+
+```php
+->fromRawMultiple([
+    'path/example_1.php' => '<?php /* ... */',
+    'path/example_2.php' => '<?php /* ... */',
+])
 ```
 
 ### that()

--- a/src/Asserts/DependsOnlyOn.php
+++ b/src/Asserts/DependsOnlyOn.php
@@ -88,7 +88,7 @@ final readonly class DependsOnlyOn implements ExprScriptInterface
         return new ViolationValueObject(
             \sprintf(
                 'Resource <promote>%s</promote> must depends only on these namespaces %s but depends %s',
-                $script->namespace ?? '',
+                $script->namespace ?? $script->getFileBasename(),
                 implode(', ', $authorisedDependence),
                 implode(', ', $violations),
             ),

--- a/src/Asserts/DependsOnlyOnFunction.php
+++ b/src/Asserts/DependsOnlyOnFunction.php
@@ -88,7 +88,7 @@ final readonly class DependsOnlyOnFunction implements ExprScriptInterface
         return new ViolationValueObject(
             \sprintf(
                 'Resource <promote>%s</promote> must depends only on functions %s but depends on %s',
-                $script->namespace ?? '',
+                $script->namespace ?? $script->getFileBasename(),
                 implode(', ', $authorisedDependence),
                 implode(', ', $violations),
             ),

--- a/src/Asserts/ToNotDependsOn.php
+++ b/src/Asserts/ToNotDependsOn.php
@@ -85,7 +85,7 @@ final readonly class ToNotDependsOn implements ExprScriptInterface
         return new ViolationValueObject(
             \sprintf(
                 'Resource <promote>%s</promote> must not depends on these namespaces %s',
-                $script->namespace ?? '',
+                $script->namespace ?? $script->getFileBasename(),
                 $this->implodeMore($dependencies),
             ),
             $this::class,

--- a/src/Asserts/ToNotDependsOnFunction.php
+++ b/src/Asserts/ToNotDependsOnFunction.php
@@ -97,7 +97,7 @@ final readonly class ToNotDependsOnFunction implements ExprScriptInterface
         return new ViolationValueObject(
             \sprintf(
                 'Resource <promote>%s</promote> must not depends on functions %s but depends on %s',
-                $script->namespace ?? '',
+                $script->namespace ?? $script->getFileBasename(),
                 implode(', ', $authorisedDependence),
                 implode(', ', $violations),
             ),

--- a/src/Asserts/ToUseDeclare.php
+++ b/src/Asserts/ToUseDeclare.php
@@ -55,7 +55,7 @@ final readonly class ToUseDeclare implements ExprScriptInterface
         return new ViolationValueObject(
             \sprintf(
                 'Resource <promote>%s</promote> must use declaration <promote>%s=%s</promote>',
-                $script->namespace ?? '',
+                $script->namespace ?? $script->getFileBasename(),
                 $this->key,
                 $this->value,
             ),

--- a/src/Builder/AllClasses.php
+++ b/src/Builder/AllClasses.php
@@ -65,7 +65,7 @@ readonly class AllClasses implements FinderInterface
             $closure($finder);
         }
 
-        $this->ruleBuilder->addFinder($finder);
+        $this->ruleBuilder->setFinder($finder);
 
         return new FinderBuilder($this->ruleBuilder, $this->abstractExpr);
     }
@@ -73,9 +73,25 @@ readonly class AllClasses implements FinderInterface
     /**
      * @return ThatInterface<T>
      */
-    public function fromRaw(string $raw): ThatInterface
+    public function fromRaw(string $raw, string $pathname = ''): ThatInterface
     {
-        $this->ruleBuilder->addRaw($raw);
+        $this->ruleBuilder->addRaw($raw, $pathname);
+
+        return new FinderBuilder($this->ruleBuilder, $this->abstractExpr);
+    }
+
+    /**
+     * @param array<array-key,string> $raws
+     *
+     * @return ThatInterface<T>
+     */
+    public function fromRawMultiple(array $raws): ThatInterface
+    {
+        foreach ($raws as $pathname => $raw) {
+            $this
+                ->ruleBuilder
+                ->addRaw($raw, is_string($pathname) ? $pathname : '');
+        }
 
         return new FinderBuilder($this->ruleBuilder, $this->abstractExpr);
     }

--- a/src/Builder/FinderBuilder.php
+++ b/src/Builder/FinderBuilder.php
@@ -24,7 +24,7 @@ class FinderBuilder extends ThatBuilder implements ThatInterface
         $expression = new $this->abstractExpr();
         $closure($expression);
 
-        $this->ruleBuilder->addThat($expression);
+        $this->ruleBuilder->setThat($expression);
 
         return new ThatBuilder($this->ruleBuilder, $this->abstractExpr);
     }

--- a/src/Builder/RuleBuilder.php
+++ b/src/Builder/RuleBuilder.php
@@ -11,7 +11,8 @@ use Symfony\Component\Finder\Finder;
 
 class RuleBuilder
 {
-    public string $raw = '';
+    /** @var array<string, string> */
+    public array $raws = [];
 
     public ?Finder $finder = null;
 
@@ -21,35 +22,40 @@ class RuleBuilder
 
     public ?Except $except = null;
 
-    public function addRaw(string $raw): self
+    public function addRaw(string $raw, string $pathname): self
     {
-        $this->raw = $raw;
+        if ($pathname === '') {
+            $nb = count($this->raws);
+            $pathname = 'tmp/run_' . $nb . '.php';
+        }
+
+        $this->raws[$pathname] = $raw;
 
         return $this;
     }
 
-    public function addFinder(Finder $finder): self
+    public function setFinder(Finder $finder): self
     {
         $this->finder = $finder;
 
         return $this;
     }
 
-    public function addThat(AbstractExpr $that): self
+    public function setThat(AbstractExpr $that): self
     {
         $this->that = $that;
 
         return $this;
     }
 
-    public function addShould(AbstractExpr $should): self
+    public function setShould(AbstractExpr $should): self
     {
         $this->should = $should;
 
         return $this;
     }
 
-    public function addExpect(Except $expect): self
+    public function setExpect(Except $expect): self
     {
         $this->except = $expect;
 
@@ -59,7 +65,7 @@ class RuleBuilder
     public function getRuleObject(): RuleValuesObject
     {
         return new RuleValuesObject(
-            raw: $this->raw,
+            raws: $this->raws,
             finder: $this->finder,
             that: $this->that,
             except: $this->except,

--- a/src/Builder/ThatBuilder.php
+++ b/src/Builder/ThatBuilder.php
@@ -30,7 +30,7 @@ class ThatBuilder implements ShouldInterface
         $expression = new $this->abstractExpr();
         $closure($expression);
 
-        $this->ruleBuilder->addShould($expression);
+        $this->ruleBuilder->setShould($expression);
 
         return $this->ruleBuilder;
     }
@@ -40,7 +40,7 @@ class ThatBuilder implements ShouldInterface
         $exception = new Except();
         $closure($exception);
 
-        $this->ruleBuilder->addExpect($exception);
+        $this->ruleBuilder->setExpect($exception);
 
         return $this;
     }

--- a/src/Contracts/FinderInterface.php
+++ b/src/Contracts/FinderInterface.php
@@ -24,5 +24,5 @@ interface FinderInterface
     /**
      * @return ThatInterface<T>
      */
-    public function fromRaw(string $raw): ThatInterface;
+    public function fromRaw(string $raw, string $pathname = ''): ThatInterface;
 }

--- a/src/Services/AnalyseService.php
+++ b/src/Services/AnalyseService.php
@@ -101,7 +101,7 @@ final class AnalyseService
                 $classname,
             );
 
-            $this->fromOutput($ruleValueObject->finder);
+            $this->fromOutput($ruleValueObject->finder, $ruleValueObject->raws);
             $this->thatOutput($ruleValueObject->that);
             $this->shouldOutput($assertBuilder);
 
@@ -115,13 +115,16 @@ final class AnalyseService
         }
     }
 
-    private function fromOutput(?Finder $finder): void
+    /**
+     * @param array<string,string> $raws
+     */
+    private function fromOutput(?Finder $finder, array $raws = []): void
     {
         if ($finder instanceof Finder) {
-            $this->prints[] = $finder->count() . ' classes from';
+            $this->prints[] = $finder->count() . ' classe(s) from';
             $this->prints[] = ' - dirs';
         } else {
-            $this->prints[] = 'Class from';
+            $this->prints[] = count($raws) . ' classe(s) from';
             $this->prints[] = ' - raw value';
         }
     }

--- a/src/Services/ExecuteService.php
+++ b/src/Services/ExecuteService.php
@@ -29,12 +29,17 @@ final class ExecuteService
             $this->ruleValuesObject->getDescriptorType(),
         );
         $this->builder = new AssertBuilder();
+        $description = null;
 
         if ($this->ruleValuesObject->finder instanceof Finder) {
             $description = $service->parse($this->ruleValuesObject->finder);
-        } elseif ($this->ruleValuesObject->raw !== '') {
-            $description = $service->parseRaw($this->ruleValuesObject->raw);
-        } else {
+        } elseif ($this->ruleValuesObject->raws !== []) {
+            foreach ($this->ruleValuesObject->raws as $filePath => $raw) {
+                $description = $service->parseRaw($raw, $filePath);
+            }
+        }
+
+        if (!$description instanceof Generator) {
             throw new InvalidArgumentException();
         }
 

--- a/src/Services/ParseService.php
+++ b/src/Services/ParseService.php
@@ -67,7 +67,7 @@ final readonly class ParseService
     /**
      * @return Generator<ClassDescription|ScriptDescription>
      */
-    public function parseRaw(string $raw, ?string $pathname = null): Generator
+    public function parseRaw(string $raw, string $pathname): Generator
     {
         try {
             /** @var array<int,Stmt> $ast */

--- a/src/ValueObjects/RuleValuesObject.php
+++ b/src/ValueObjects/RuleValuesObject.php
@@ -12,8 +12,11 @@ use Symfony\Component\Finder\Finder;
 
 final readonly class RuleValuesObject
 {
+    /**
+     * @param array<string, string> $raws
+     */
     public function __construct(
-        public string $raw,
+        public array $raws,
         public ?Finder $finder,
         public ?AbstractExpr $that,
         public ?Except $except,

--- a/src/Visitors/ScriptDescriptionVisitor.php
+++ b/src/Visitors/ScriptDescriptionVisitor.php
@@ -45,7 +45,7 @@ final class ScriptDescriptionVisitor extends NodeVisitorAbstract
 
         if (!$this->script instanceof ScriptDescription) {
             $this->script = new ScriptDescription(
-                namespace: $this->namespace?->name?->toString() ?? '',
+                namespace: $this->namespace?->name?->toString(),
                 declare: $this->declare,
             );
         }

--- a/tests/Feature/TestException.php
+++ b/tests/Feature/TestException.php
@@ -19,7 +19,7 @@ final class TestException extends TestBuilder
     {
         $this
             ->allClasses()
-            ->fromDir('tests/Fixture/Exceptions')
+            ->fromRawMultiple($this->getClassLikeProvider())
             ->should(
                 static fn (Expr $expr): Expr => $expr
                     ->or(
@@ -33,5 +33,36 @@ final class TestException extends TestBuilder
                             ),
                     ),
             );
+    }
+
+    /**
+     * @return array<int,string>
+     */
+    private function getClassLikeProvider(): array
+    {
+        return [
+            <<<PHP
+            <?php
+                
+            declare(strict_types=1);
+                
+            namespace StructuraPhp\\Structura\\Tests\\Fixture\\Exceptions;
+                
+            use InvalidArgumentException;
+                
+            class InvalidException extends InvalidArgumentException {}
+            PHP,
+            <<<PHP
+            <?php
+                
+            declare(strict_types=1);
+                
+            namespace StructuraPhp\\Structura\\Tests\\Fixture\\Exceptions;
+                
+            use Exception;
+                
+            class UserException extends Exception {}
+            PHP,
+        ];
     }
 }

--- a/tests/Unit/Asserts/DependsOnlyOnFunctionTest.php
+++ b/tests/Unit/Asserts/DependsOnlyOnFunctionTest.php
@@ -86,8 +86,10 @@ class DependsOnlyOnFunctionTest extends TestCase
     }
 
     #[DataProvider('getScriptWithFunction')]
-    public function testShouldFailDependsOnlyOnFunctionWithScript(string $raw): void
-    {
+    public function testShouldFailDependsOnlyOnFunctionWithScript(
+        string $raw,
+        string $exceptName,
+    ): void {
         $rules = $this
             ->allScripts()
             ->fromRaw($raw)
@@ -103,7 +105,7 @@ class DependsOnlyOnFunctionTest extends TestCase
             $rules,
             \sprintf(
                 'Resource <promote>%s</promote> must depends only on functions %s but depends on %s',
-                'Foo',
+                $exceptName,
                 'strtoupper, mb_.+',
                 'array_merge, strtolower',
             ),
@@ -126,7 +128,7 @@ class DependsOnlyOnFunctionTest extends TestCase
 
     public static function getScriptWithFunction(): Generator
     {
-        yield 'script' => [
+        yield 'script with namespace' => [
             <<<'PHP'
             <?php
 
@@ -137,6 +139,19 @@ class DependsOnlyOnFunctionTest extends TestCase
                 strtolower("FOO");
             }
             PHP,
+            'Foo',
+        ];
+
+        yield 'script without namespace' => [
+            <<<'PHP'
+            <?php
+
+            function bar() {
+                array_merge([], []);
+                strtolower("FOO");
+            }
+            PHP,
+            'tmp/run_0.php',
         ];
     }
 }

--- a/tests/Unit/Asserts/DependsOnlyOnTest.php
+++ b/tests/Unit/Asserts/DependsOnlyOnTest.php
@@ -112,8 +112,10 @@ final class DependsOnlyOnTest extends TestCase
     }
 
     #[DataProvider('getScriptWithDependsProvider')]
-    public function testShouldFailDependsOnlyOnWithScript(string $raw): void
-    {
+    public function testShouldFailDependsOnlyOnWithScript(
+        string $raw,
+        string $exceptName,
+    ): void {
         $rules = $this
             ->allScripts()
             ->fromRaw($raw)
@@ -125,7 +127,8 @@ final class DependsOnlyOnTest extends TestCase
         self::assertRulesViolation(
             $rules,
             \sprintf(
-                'Resource <promote>Foo</promote> must depends only on these namespaces %s but depends %s, %s, %s, %s',
+                'Resource <promote>%s</promote> must depends only on these namespaces %s but depends %s, %s, %s, %s',
+                $exceptName,
                 'Depend\Bap',
                 ArrayAccess::class,
                 'Depend\Bar',
@@ -160,7 +163,7 @@ final class DependsOnlyOnTest extends TestCase
 
     public static function getScriptWithDependsProvider(): Generator
     {
-        yield 'script' => [
+        yield 'script with namespace' => [
             <<<'PHP'
             <?php
 
@@ -178,6 +181,26 @@ final class DependsOnlyOnTest extends TestCase
                 return $this->arrayAccess['foo'] ?? throw new \Exception();
             }
             PHP,
+            'Foo',
+        ];
+
+        yield 'script without namespace' => [
+            <<<'PHP'
+            <?php
+
+            use ArrayAccess;
+            use Depend\Bap;
+            use Depend\Bar;
+            
+            function foo(ArrayAccess $arrayAccess) {
+                \Stringable::class;
+            }
+
+            function bar(): string {
+                return $this->arrayAccess['foo'] ?? throw new \Exception();
+            }
+            PHP,
+            'tmp/run_0.php',
         ];
     }
 }

--- a/tests/Unit/Asserts/NotDependsOnFunctionTest.php
+++ b/tests/Unit/Asserts/NotDependsOnFunctionTest.php
@@ -86,8 +86,10 @@ class NotDependsOnFunctionTest extends TestCase
     }
 
     #[DataProvider('getScriptWithFunction')]
-    public function testShouldFailNotDependsOnFunctionWithScript(string $raw): void
-    {
+    public function testShouldFailNotDependsOnFunctionWithScript(
+        string $raw,
+        string $exceptName,
+    ): void {
         $rules = $this
             ->allScripts()
             ->fromRaw($raw)
@@ -103,7 +105,7 @@ class NotDependsOnFunctionTest extends TestCase
             $rules,
             \sprintf(
                 'Resource <promote>%s</promote> must not depends on functions %s but depends on %s',
-                'Foo',
+                $exceptName,
                 'strtolower, array_.+',
                 'array_merge, strtolower',
             ),
@@ -126,7 +128,7 @@ class NotDependsOnFunctionTest extends TestCase
 
     public static function getScriptWithFunction(): Generator
     {
-        yield 'script' => [
+        yield 'script with namespace' => [
             <<<'PHP'
             <?php
 
@@ -137,6 +139,19 @@ class NotDependsOnFunctionTest extends TestCase
                 strtolower("FOO");
             }
             PHP,
+            'Foo',
+        ];
+
+        yield 'script without namespace' => [
+            <<<'PHP'
+            <?php
+
+            function bar() {
+                array_merge([], []);
+                strtolower("FOO");
+            }
+            PHP,
+            'tmp/run_0.php',
         ];
     }
 }

--- a/tests/Unit/Asserts/OrTest.php
+++ b/tests/Unit/Asserts/OrTest.php
@@ -7,8 +7,10 @@ namespace StructuraPhp\Structura\Tests\Unit\Asserts;
 use AppendIterator;
 use ArrayIterator;
 use Exception;
+use Generator;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use StructuraPhp\Structura\Expr;
 use StructuraPhp\Structura\Tests\Fixture\Exceptions\UserException;
@@ -19,11 +21,15 @@ final class OrTest extends TestCase
 {
     use ArchitectureAsserts;
 
-    public function testShouldOr(): void
+    /**
+     * @param array<int,string> $raws
+     */
+    #[DataProvider('getClassLikeProvider')]
+    public function testShouldOr(array $raws): void
     {
         $rules = $this
             ->allClasses()
-            ->fromDir('tests/Fixture/Exceptions')
+            ->fromRawMultiple($raws)
             ->should(
                 static fn (Expr $assert): Expr => $assert
                     ->or(
@@ -42,11 +48,15 @@ final class OrTest extends TestCase
         );
     }
 
-    public function testShouldFailToOr(): void
+    /**
+     * @param array<int,string> $raws
+     */
+    #[DataProvider('getClassLikeProvider')]
+    public function testShouldFailToOr(array $raws): void
     {
         $rules = $this
             ->allClasses()
-            ->fromDir('tests/Fixture/Exceptions')
+            ->fromRawMultiple($raws)
             ->should(
                 static fn (Expr $assert): Expr => $assert
                     ->or(
@@ -65,5 +75,35 @@ final class OrTest extends TestCase
                 UserException::class,
             ),
         );
+    }
+
+    public static function getClassLikeProvider(): Generator
+    {
+        yield [
+            [
+                <<<PHP
+                <?php
+                
+                declare(strict_types=1);
+                
+                namespace StructuraPhp\\Structura\\Tests\\Fixture\\Exceptions;
+                
+                use InvalidArgumentException;
+                
+                class InvalidException extends InvalidArgumentException {}
+                PHP,
+                <<<PHP
+                <?php
+                
+                declare(strict_types=1);
+                
+                namespace StructuraPhp\\Structura\\Tests\\Fixture\\Exceptions;
+                
+                use Exception;
+                
+                class UserException extends Exception {}
+                PHP,
+            ],
+        ];
     }
 }

--- a/tests/Unit/Asserts/ToUseStrictTypesTest.php
+++ b/tests/Unit/Asserts/ToUseStrictTypesTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace StructuraPhp\Structura\Tests\Unit\Asserts;
 
+use Generator;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use StructuraPhp\Structura\Expr;
 use StructuraPhp\Structura\ExprScript;
@@ -60,10 +62,16 @@ final class ToUseStrictTypesTest extends TestCase
             $rules,
             'Resource <promote>Foo</promote> must use declaration <promote>strict_types=1</promote>',
         );
+    }
 
+    #[DataProvider('getScriptTypeProvider')]
+    public function testShouldFailToUserStrictTypeWithScript(
+        string $raw,
+        string $exceptName,
+    ): void {
         $rules = $this
             ->allScripts()
-            ->fromRaw('<?php namespace Foo; $foo=1;')
+            ->fromRaw($raw)
             ->should(
                 static fn (ExprScript $assert): ExprScript => $assert
                     ->toUseStrictTypes(),
@@ -71,7 +79,23 @@ final class ToUseStrictTypesTest extends TestCase
 
         self::assertRulesViolation(
             $rules,
-            'Resource <promote>Foo</promote> must use declaration <promote>strict_types=1</promote>',
+            sprintf(
+                'Resource <promote>%s</promote> must use declaration <promote>strict_types=1</promote>',
+                $exceptName,
+            ),
         );
+    }
+
+    public static function getScriptTypeProvider(): Generator
+    {
+        yield 'script with namespace' => [
+            '<?php namespace Foo; $foo = 1;',
+            'Foo',
+        ];
+
+        yield 'script without namespace' => [
+            '<?php $foo = 1;',
+            'tmp/run_0.php',
+        ];
     }
 }

--- a/tests/Unit/Services/AnalyseServiceTest.php
+++ b/tests/Unit/Services/AnalyseServiceTest.php
@@ -30,7 +30,7 @@ final class AnalyseServiceTest extends TestCase
 
         $expected = <<<'EOF'
         <violation> ERROR </violation> Asserts architecture rules in StructuraPhp\Structura\Tests\Feature\TestAssert
-        40 classes from
+        40 classe(s) from
          - dirs
         That
          - to implement <promote>StructuraPhp\Structura\Contracts\ExprInterface</promote>
@@ -45,7 +45,7 @@ final class AnalyseServiceTest extends TestCase
          <green>✔</green> to have method <promote>__construct</promote>
 
         <violation> ERROR </violation> Controllers architecture rules in StructuraPhp\Structura\Tests\Feature\TestController
-        3 classes from
+        3 classe(s) from
          - dirs
         Should
          <green>✔</green> to be classes
@@ -57,8 +57,8 @@ final class AnalyseServiceTest extends TestCase
          <fire>✘</fire> depends only on these namespaces <promote>StructuraPhp\Structura\Tests\Fixture\Concerns\HasFactory, StructuraPhp\Structura\Tests\Fixture\Http\Controller\RoleController, StructuraPhp\Structura\Tests\Fixture\Contract\ShouldQueueInterface, [1+]</promote> <fire>2 error(s)</fire>
 
         <pass> PASS </pass> Exceptions architecture rules in StructuraPhp\Structura\Tests\Feature\TestException
-        2 classes from
-         - dirs
+        2 classe(s) from
+         - raw value
         Should
          <green>✔</green> to extend <promote>InvalidArgumentException</promote>
            | to extend <promote>Exception</promote>
@@ -66,7 +66,7 @@ final class AnalyseServiceTest extends TestCase
              & to extend <promote>BadMethodCallException</promote>
 
         <pass> PASS </pass> Asserts architecture rules in StructuraPhp\Structura\Tests\Feature\TestVoid
-        105 classes from
+        105 classe(s) from
          - dirs
         That
         Should

--- a/tests/Unit/Services/ExecuteServiceTest.php
+++ b/tests/Unit/Services/ExecuteServiceTest.php
@@ -78,7 +78,7 @@ final class ExecuteServiceTest extends TestCase
         );
         self::assertSame(1, $violation->line);
         self::assertSame(ToExtend::class, $violation->assertClassname);
-        self::assertNull($violation->pathname);
+        self::assertSame($violation->pathname, 'tmp/run_0.php');
         self::assertSame('', $violation->messageCustom);
 
         $warning = $result->getWarnings();


### PR DESCRIPTION
## Description

Added the `fromRawMultiple()` method to add multiple PHP codes as character strings.

In addition, each PHP code in character string form is associated with a temporary file name.

By default, `tmp\run_<number>.php`