### PR TITLE
feat(command): add progress bar for analyse command

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,9 +235,12 @@ php bin/structura analyze
 
 ### Cli options
 
-- `--format-error=<FORMAT>`
+- `-f, --error-format[=ERROR-FORMAT]`
   - `text`: Default. For human consumption.
   - `github`: Creates GitHub Actions compatible output.
+- `-p, --progress-format[=PROGRESS-FORMAT]`
+  - `text`: Default. For human consumption.
+  - `bar`: For progress bar.
 
 ## Assertions
 

--- a/src/Contracts/ProgressFormatterInterface.php
+++ b/src/Contracts/ProgressFormatterInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StructuraPhp\Structura\Contracts;
+
+use StructuraPhp\Structura\ValueObjects\AnalyseValueObject;
+use Symfony\Component\Console\Output\OutputInterface;
+
+interface ProgressFormatterInterface
+{
+    public function progressStart(OutputInterface $output, int $max): void;
+
+    public function progressAdvance(OutputInterface $output, AnalyseValueObject $analyseValueObject): void;
+
+    public function progressFinish(OutputInterface $output): void;
+}

--- a/src/Enums/ErrorFormatterType.php
+++ b/src/Enums/ErrorFormatterType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StructuraPhp\Structura\Enums;
+
+enum ErrorFormatterType: string
+{
+    case Text = 'text';
+    case Github = 'github';
+}

--- a/src/Enums/ProgressFormatterType.php
+++ b/src/Enums/ProgressFormatterType.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace StructuraPhp\Structura\Enums;
 
-enum FormatterType: string
+enum ProgressFormatterType: string
 {
+    case Bar = 'bar';
     case Text = 'text';
-    case Github = 'github';
 }

--- a/src/Formatter/Error/ErrorGithubFormatter.php
+++ b/src/Formatter/Error/ErrorGithubFormatter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace StructuraPhp\Structura\Formatter;
+namespace StructuraPhp\Structura\Formatter\Error;
 
 use StructuraPhp\Structura\Contracts\ErrorFormatterInterface;
 use StructuraPhp\Structura\ValueObjects\AnalyseValueObject;
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @phpstan-import-type ViolationsByTest from AnalyseValueObject
  */
-class GithubFormatter implements ErrorFormatterInterface
+class ErrorGithubFormatter implements ErrorFormatterInterface
 {
     public function formatErrors(AnalyseValueObject $analyseValueObject, OutputInterface $output): int
     {

--- a/src/Formatter/Error/ErrorTextFormatter.php
+++ b/src/Formatter/Error/ErrorTextFormatter.php
@@ -2,22 +2,19 @@
 
 declare(strict_types=1);
 
-namespace StructuraPhp\Structura\Formatter;
+namespace StructuraPhp\Structura\Formatter\Error;
 
 use DateTime;
 use Exception;
-use StructuraPhp\Structura\AbstractExpr;
 use StructuraPhp\Structura\Console\Enums\StyleCustom;
 use StructuraPhp\Structura\Contracts\ErrorFormatterInterface;
 use StructuraPhp\Structura\ValueObjects\AnalyseValueObject;
-use StructuraPhp\Structura\ValueObjects\AssertValueObject;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Finder\Finder;
 
 /**
  * @phpstan-import-type ViolationsByTest from AnalyseValueObject
  */
-final class TextFormatter implements ErrorFormatterInterface
+final class ErrorTextFormatter implements ErrorFormatterInterface
 {
     /** @var array<int,string> */
     private array $prints = [];
@@ -26,22 +23,6 @@ final class TextFormatter implements ErrorFormatterInterface
         AnalyseValueObject $analyseValueObject,
         OutputInterface $output,
     ): int {
-        foreach ($analyseValueObject->analyseTestValueObjects as $data) {
-            $this->prints[] = \sprintf(
-                '%s %s in %s',
-                $data->assertValueObject->countAssertsFailure() === 0
-                    ? '<pass> PASS </pass>'
-                    : '<violation> ERROR </violation>',
-                $data->textDox,
-                $data->classname,
-            );
-            $this->fromOutput($data->ruleValueObject->finder, $data->ruleValueObject->raws);
-            $this->thatOutput($data->ruleValueObject->that);
-            $this->shouldOutput($data->assertValueObject);
-            $this->prints[] = '';
-        }
-
-        $this->prints[] = '';
         $violations = array_merge(...$analyseValueObject->violationsByTests);
 
         $this->failedOutput($violations);
@@ -137,58 +118,5 @@ final class TextFormatter implements ErrorFormatterInterface
         return $now === false
             ? throw new Exception()
             : $now;
-    }
-
-    /**
-     * @param array<string,string> $raws
-     */
-    private function fromOutput(?Finder $finder, array $raws = []): void
-    {
-        if ($finder instanceof Finder) {
-            $this->prints[] = $finder->count() . ' classe(s) from';
-            $this->prints[] = ' - dirs';
-        } else {
-            $this->prints[] = count($raws) . ' classe(s) from';
-            $this->prints[] = ' - raw value';
-        }
-    }
-
-    private function thatOutput(?AbstractExpr $builder): void
-    {
-        if (!$builder instanceof AbstractExpr) {
-            return;
-        }
-
-        $this->prints[] = 'That';
-
-        foreach ($builder as $expr) {
-            $this->prints[] = \sprintf(' - %s', $expr);
-        }
-    }
-
-    private function shouldOutput(AssertValueObject $assertValueObject): void
-    {
-        $this->prints[] = 'Should';
-
-        foreach ($assertValueObject->pass as $message => $isPass) {
-            if ($isPass === 0) {
-                $this->prints[] = \sprintf(
-                    ' <fire>✘</fire> %s <fire>%d error(s)</fire>',
-                    $message,
-                    $assertValueObject->countViolation($message),
-                );
-            } else {
-                $countWarning = $assertValueObject->countWarning($message);
-                $warning = $countWarning !== 0
-                    ? sprintf(' <warning>%d warning(s)</warning>', $countWarning)
-                    : '';
-
-                $this->prints[] = \sprintf(
-                    ' <green>✔</green> %s%s',
-                    $message,
-                    $warning,
-                );
-            }
-        }
     }
 }

--- a/src/Formatter/Progress/ProgressBarFormatter.php
+++ b/src/Formatter/Progress/ProgressBarFormatter.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StructuraPhp\Structura\Formatter\Progress;
+
+use RuntimeException;
+use StructuraPhp\Structura\Contracts\ProgressFormatterInterface;
+use StructuraPhp\Structura\ValueObjects\AnalyseValueObject;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\OutputStyle;
+
+class ProgressBarFormatter implements ProgressFormatterInterface
+{
+    public function progressStart(OutputInterface $output, int $max): void
+    {
+        $output instanceof OutputStyle
+            ? $output->progressStart($max)
+            : throw new RuntimeException();
+    }
+
+    public function progressAdvance(OutputInterface $output, AnalyseValueObject $analyseValueObject): void
+    {
+        $output instanceof OutputStyle
+            ? $output->progressAdvance()
+            : throw new RuntimeException();
+    }
+
+    public function progressFinish(OutputInterface $output): void
+    {
+        $output instanceof OutputStyle
+            ? $output->progressFinish()
+            : throw new RuntimeException();
+    }
+}

--- a/src/Formatter/Progress/ProgressTextFormatter.php
+++ b/src/Formatter/Progress/ProgressTextFormatter.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StructuraPhp\Structura\Formatter\Progress;
+
+use StructuraPhp\Structura\AbstractExpr;
+use StructuraPhp\Structura\Console\Enums\StyleCustom;
+use StructuraPhp\Structura\Contracts\ProgressFormatterInterface;
+use StructuraPhp\Structura\ValueObjects\AnalyseValueObject;
+use StructuraPhp\Structura\ValueObjects\AssertValueObject;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * @phpstan-import-type ViolationsByTest from AnalyseValueObject
+ */
+final class ProgressTextFormatter implements ProgressFormatterInterface
+{
+    /** @var array<int,string> */
+    private array $prints = [];
+
+    public function progressStart(OutputInterface $output, int $max): void
+    {
+        // Nothing
+    }
+
+    public function progressAdvance(OutputInterface $output, AnalyseValueObject $analyseValueObject): void
+    {
+        foreach ($analyseValueObject->analyseTestValueObjects as $data) {
+            $this->prints[] = \sprintf(
+                '%s %s in %s',
+                $data->assertValueObject->countAssertsFailure() === 0
+                    ? '<pass> PASS </pass>'
+                    : '<violation> ERROR </violation>',
+                $data->textDox,
+                $data->classname,
+            );
+            $this->fromOutput($data->ruleValueObject->finder, $data->ruleValueObject->raws);
+            $this->thatOutput($data->ruleValueObject->that);
+            $this->shouldOutput($data->assertValueObject);
+            $this->prints[] = '';
+
+            foreach ($this->prints as $print) {
+                $this->styleCustom($output)->writeln($print);
+            }
+
+            unset($this->prints);
+        }
+
+        $output->writeln('');
+    }
+
+    public function progressFinish(OutputInterface $output): void
+    {
+        // Nothing
+    }
+
+    private function styleCustom(OutputInterface $output): OutputInterface
+    {
+        foreach (StyleCustom::cases() as $style) {
+            $output
+                ->getFormatter()
+                ->setStyle(
+                    $style->value,
+                    $style->getOutputFormatterStyle(),
+                );
+        }
+
+        return $output;
+    }
+
+    /**
+     * @param array<string,string> $raws
+     */
+    private function fromOutput(?Finder $finder, array $raws = []): void
+    {
+        if ($finder instanceof Finder) {
+            $this->prints[] = $finder->count() . ' classe(s) from';
+            $this->prints[] = ' - dirs';
+        } else {
+            $this->prints[] = count($raws) . ' classe(s) from';
+            $this->prints[] = ' - raw value';
+        }
+    }
+
+    private function thatOutput(?AbstractExpr $builder): void
+    {
+        if (!$builder instanceof AbstractExpr) {
+            return;
+        }
+
+        $this->prints[] = 'That';
+
+        foreach ($builder as $expr) {
+            $this->prints[] = \sprintf(' - %s', $expr);
+        }
+    }
+
+    private function shouldOutput(AssertValueObject $assertValueObject): void
+    {
+        $this->prints[] = 'Should';
+
+        foreach ($assertValueObject->pass as $message => $isPass) {
+            if ($isPass === 0) {
+                $this->prints[] = \sprintf(
+                    ' <fire>✘</fire> %s <fire>%d error(s)</fire>',
+                    $message,
+                    $assertValueObject->countViolation($message),
+                );
+            } else {
+                $countWarning = $assertValueObject->countWarning($message);
+                $warning = $countWarning !== 0
+                    ? sprintf(' <warning>%d warning(s)</warning>', $countWarning)
+                    : '';
+
+                $this->prints[] = \sprintf(
+                    ' <green>✔</green> %s%s',
+                    $message,
+                    $warning,
+                );
+            }
+        }
+    }
+}

--- a/src/Services/AnalyseService.php
+++ b/src/Services/AnalyseService.php
@@ -33,7 +33,26 @@ final class AnalyseService
         private readonly StructuraConfig $structuraConfig,
     ) {}
 
-    public function analyse(): AnalyseValueObject
+    /**
+     * @param class-string<TestBuilder> $ruleClassname
+     */
+    public function analyse(
+        float $timeStart,
+        string $ruleClassname,
+    ): AnalyseValueObject {
+        $this->executeTests($ruleClassname);
+
+        return new AnalyseValueObject(
+            timeStart: $timeStart,
+            countPass: $this->countPass,
+            countViolation: $this->countViolation,
+            countWarning: $this->countWarning,
+            violationsByTests: $this->violationsByTests,
+            analyseTestValueObjects: $this->analyseTestValueObjects,
+        );
+    }
+
+    public function analyses(): AnalyseValueObject
     {
         $timeStart = microtime(true);
 

--- a/tests/Unit/Formatter/Error/ErrorGithubFormatterTest.php
+++ b/tests/Unit/Formatter/Error/ErrorGithubFormatterTest.php
@@ -2,23 +2,23 @@
 
 declare(strict_types=1);
 
-namespace StructuraPhp\Structura\Tests\Unit\Formatter;
+namespace StructuraPhp\Structura\Tests\Unit\Formatter\Error;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\TestCase;
-use StructuraPhp\Structura\Formatter\GithubFormatter;
+use StructuraPhp\Structura\Formatter\Error\ErrorGithubFormatter;
 use StructuraPhp\Structura\Tests\DataProvider\FormatterDataProvider;
 use StructuraPhp\Structura\ValueObjects\AnalyseValueObject;
 use Symfony\Component\Console\Output\BufferedOutput;
 
-#[CoversClass(GithubFormatter::class)]
-class GithubFormatterTest extends TestCase
+#[CoversClass(ErrorGithubFormatter::class)]
+class ErrorGithubFormatterTest extends TestCase
 {
     #[DataProviderExternal(FormatterDataProvider::class, 'getAnalyseValueObject')]
     public function testOutput(AnalyseValueObject $except): void
     {
-        $text = new GithubFormatter();
+        $text = new ErrorGithubFormatter();
 
         $buffer = new BufferedOutput();
 

--- a/tests/Unit/Formatter/Error/ErrorTextFormatterTest.php
+++ b/tests/Unit/Formatter/Error/ErrorTextFormatterTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StructuraPhp\Structura\Tests\Unit\Formatter\Error;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\TestCase;
+use StructuraPhp\Structura\Formatter\Error\ErrorTextFormatter;
+use StructuraPhp\Structura\Tests\DataProvider\FormatterDataProvider;
+use StructuraPhp\Structura\Tests\Helper\OutputFormatter;
+use StructuraPhp\Structura\ValueObjects\AnalyseValueObject;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+#[CoversClass(ErrorTextFormatter::class)]
+class ErrorTextFormatterTest extends TestCase
+{
+    #[DataProviderExternal(FormatterDataProvider::class, 'getAnalyseValueObject')]
+    public function testOutput(AnalyseValueObject $except): void
+    {
+        $text = new ErrorTextFormatter();
+
+        $buffer = new BufferedOutput(formatter: new OutputFormatter());
+        $buffer->setDecorated(true);
+
+        $text->formatErrors($except, $buffer);
+
+        $expected = <<<'EOF'
+        <violation> ERROR LIST </violation>
+
+        Resource <promote>x</promote> must be a final class
+        example.php:1
+
+        Tests:    <green>10 passed</green>, <fire>10 failed</fire>, <warning>1 warning</warning> (21 assertion)
+        EOF;
+
+        $expected = explode(PHP_EOL, $expected);
+
+        $fetch = explode(PHP_EOL, $buffer->fetch());
+
+        foreach ($expected as $key => $line) {
+            self::assertSame($line, $fetch[$key], sprintf('Error line %d', $key));
+        }
+    }
+}

--- a/tests/Unit/Formatter/Progress/ProgressTextFormatterTest.php
+++ b/tests/Unit/Formatter/Progress/ProgressTextFormatterTest.php
@@ -2,29 +2,32 @@
 
 declare(strict_types=1);
 
-namespace StructuraPhp\Structura\Tests\Unit\Formatter;
+namespace StructuraPhp\Structura\Tests\Unit\Formatter\Progress;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\TestCase;
-use StructuraPhp\Structura\Formatter\TextFormatter;
+use StructuraPhp\Structura\Formatter\Error\ErrorTextFormatter;
+use StructuraPhp\Structura\Formatter\Progress\ProgressTextFormatter;
 use StructuraPhp\Structura\Tests\DataProvider\FormatterDataProvider;
 use StructuraPhp\Structura\Tests\Helper\OutputFormatter;
 use StructuraPhp\Structura\ValueObjects\AnalyseValueObject;
 use Symfony\Component\Console\Output\BufferedOutput;
 
-#[CoversClass(TextFormatter::class)]
-class TextFormatterTest extends TestCase
+#[CoversClass(ErrorTextFormatter::class)]
+class ProgressTextFormatterTest extends TestCase
 {
     #[DataProviderExternal(FormatterDataProvider::class, 'getAnalyseValueObject')]
     public function testOutput(AnalyseValueObject $except): void
     {
-        $text = new TextFormatter();
+        $text = new ProgressTextFormatter();
 
         $buffer = new BufferedOutput(formatter: new OutputFormatter());
         $buffer->setDecorated(true);
 
-        $text->formatErrors($except, $buffer);
+        $text->progressStart($buffer, 1);
+        $text->progressAdvance($buffer, $except);
+        $text->progressFinish($buffer);
 
         $expected = <<<'EOF'
         <violation> ERROR </violation> Asserts architecture rules in TestAssert
@@ -37,13 +40,6 @@ class TextFormatterTest extends TestCase
          <green>✔</green> to be readonly <warning>1 warning(s)</warning>
          <fire>✘</fire> to be final <fire>1 error(s)</fire>
 
-
-        <violation> ERROR LIST </violation>
-
-        Resource <promote>x</promote> must be a final class
-        example.php:1
-
-        Tests:    <green>10 passed</green>, <fire>10 failed</fire>, <warning>1 warning</warning> (21 assertion)
         EOF;
 
         $expected = explode(PHP_EOL, $expected);

--- a/tests/Unit/Services/AnalyseServiceTest.php
+++ b/tests/Unit/Services/AnalyseServiceTest.php
@@ -7,7 +7,7 @@ namespace StructuraPhp\Structura\Tests\Unit\Services;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use StructuraPhp\Structura\Configs\StructuraConfig;
-use StructuraPhp\Structura\Formatter\TextFormatter;
+use StructuraPhp\Structura\Formatter\Progress\ProgressTextFormatter;
 use StructuraPhp\Structura\Services\AnalyseService;
 use StructuraPhp\Structura\Tests\Helper\OutputFormatter;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -25,13 +25,13 @@ final class AnalyseServiceTest extends TestCase
                 ),
         );
 
-        $result = $service->analyse();
-        $text = new TextFormatter();
+        $result = $service->analyses();
+        $formatter = new ProgressTextFormatter();
 
         $buffer = new BufferedOutput(formatter: new OutputFormatter());
         $buffer->setDecorated(true);
 
-        $text->formatErrors($result, $buffer);
+        $formatter->progressAdvance($buffer, $result);
 
         self::assertSame(5, $result->countViolation);
         self::assertSame(10, $result->countPass);
@@ -75,7 +75,7 @@ final class AnalyseServiceTest extends TestCase
              & to extend <promote>BadMethodCallException</promote>
 
         <pass> PASS </pass> Asserts architecture rules in StructuraPhp\Structura\Tests\Feature\TestVoid
-        113 classe(s) from
+        117 classe(s) from
          - dirs
         That
         Should


### PR DESCRIPTION
Description

Adds an option to choose the analysis progress format

```
- `-p, --progress-format[=PROGRESS-FORMAT]`
  - `text`: Default. For human consumption.
  - `bar`: For progress bar.
```