### PR TITLE
fix(analyse): return error

### DIFF
--- a/src/Console/Commands/AnalyzeCommand.php
+++ b/src/Console/Commands/AnalyzeCommand.php
@@ -86,9 +86,8 @@ final class AnalyzeCommand extends Command
         $progressFormatter->progressFinish($io);
 
         $errorFormatter = $this->getErrorFormatter($input);
-        $errorFormatter->formatErrors($result, $output);
 
-        return self::SUCCESS;
+        return $errorFormatter->formatErrors($result, $output);
     }
 
     protected function configure(): void

--- a/src/Formatter/Error/ErrorTextFormatter.php
+++ b/src/Formatter/Error/ErrorTextFormatter.php
@@ -36,7 +36,7 @@ final class ErrorTextFormatter implements ErrorFormatterInterface
             $this->styleCustom($output)->writeln($print);
         }
 
-        return $violations !== []
+        return $violations === []
             ? self::SUCCESS
             : self::ERROR;
     }

--- a/tests/Unit/Formatter/Error/ErrorGithubFormatterTest.php
+++ b/tests/Unit/Formatter/Error/ErrorGithubFormatterTest.php
@@ -22,7 +22,7 @@ class ErrorGithubFormatterTest extends TestCase
 
         $buffer = new BufferedOutput();
 
-        $text->formatErrors($except, $buffer);
+        $output = $text->formatErrors($except, $buffer);
 
         $expected = <<<'EOF'
         ::error file=example.php,line=1,col=0::Resource <promote>x</promote> must be a final class
@@ -33,6 +33,7 @@ class ErrorGithubFormatterTest extends TestCase
 
         $fetch = explode(PHP_EOL, $buffer->fetch());
 
+        self::assertSame(ErrorGithubFormatter::ERROR, $output);
         foreach ($expected as $key => $line) {
             self::assertSame($line, $fetch[$key]);
         }

--- a/tests/Unit/Formatter/Error/ErrorTextFormatterTest.php
+++ b/tests/Unit/Formatter/Error/ErrorTextFormatterTest.php
@@ -24,7 +24,7 @@ class ErrorTextFormatterTest extends TestCase
         $buffer = new BufferedOutput(formatter: new OutputFormatter());
         $buffer->setDecorated(true);
 
-        $text->formatErrors($except, $buffer);
+        $output = $text->formatErrors($except, $buffer);
 
         $expected = <<<'EOF'
         <violation> ERROR LIST </violation>
@@ -39,6 +39,7 @@ class ErrorTextFormatterTest extends TestCase
 
         $fetch = explode(PHP_EOL, $buffer->fetch());
 
+        self::assertSame(ErrorTextFormatter::ERROR, $output);
         foreach ($expected as $key => $line) {
             self::assertSame($line, $fetch[$key], sprintf('Error line %d', $key));
         }


### PR DESCRIPTION
### Description

returns the error code provided by the error formatter
